### PR TITLE
Package-level cycle detection via slices

### DIFF
--- a/library/src/main/kotlin/io/github/baole/konture/Extensions.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/Extensions.kt
@@ -1,5 +1,6 @@
 /*
- * Copyright 2026 Bao Le Duc
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc, Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -48,6 +49,15 @@ fun Konture.properties(sourceSets: SourceSetSelector) = PropertiesRuleBuilder(pr
 fun Konture.files() = FilesRuleBuilder(projectGraph)
 
 fun Konture.files(sourceSets: SourceSetSelector) = FilesRuleBuilder(projectGraph, sourceSets)
+
+/**
+ * Access the slice declarative assertion rule builder.
+ * Groups packages into slices by a capture-group pattern and asserts relationships between them,
+ * such as cycle-freedom.
+ */
+fun Konture.slices() = SlicesRuleBuilder(projectGraph)
+
+fun Konture.slices(sourceSets: SourceSetSelector) = SlicesRuleBuilder(projectGraph, sourceSets)
 
 /**
  * Verifies that there are no package or module dependency cycles in the project.
@@ -178,6 +188,21 @@ fun Konture.files(
     block: FilesRuleBuilder.() -> Unit,
 ) {
     FilesRuleBuilder(projectGraph, sourceSets).apply(block).check()
+}
+
+/**
+ * Define and run slice rules inside a block-based DSL context.
+ * Automatically checks the rules at the end of the block.
+ */
+fun Konture.slices(block: SlicesRuleBuilder.() -> Unit) {
+    SlicesRuleBuilder(projectGraph).apply(block).check()
+}
+
+fun Konture.slices(
+    sourceSets: SourceSetSelector,
+    block: SlicesRuleBuilder.() -> Unit,
+) {
+    SlicesRuleBuilder(projectGraph, sourceSets).apply(block).check()
 }
 
 /**

--- a/library/src/main/kotlin/io/github/baole/konture/KontureContext.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/KontureContext.kt
@@ -1,5 +1,6 @@
 /*
- * Copyright 2026 Bao Le Duc
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc, Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -75,6 +76,15 @@ class KontureContext(
         val builder = FilesRuleBuilder(projectGraph)
         builder.apply(block)
         addSuite("files") { builder.check() }
+    }
+
+    /**
+     * Declares a suite of slice rules inside this architecture validation context.
+     */
+    fun slices(block: SlicesRuleBuilder.() -> Unit) {
+        val builder = SlicesRuleBuilder(projectGraph)
+        builder.apply(block)
+        addSuite("slices") { builder.check() }
     }
 
     /**

--- a/library/src/main/kotlin/io/github/baole/konture/Slice.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/Slice.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Octavio Calleya Garcia (@octaviospain)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture
+
+/**
+ * A group of packages sharing the same slice key, derived from a slice pattern's capture group.
+ *
+ * Slices are the unit over which package-level relationships such as cycle-freedom and mutual
+ * isolation are asserted. For the pattern `com.acme.(*)..`, the packages `com.acme.payment` and
+ * `com.acme.payment.api` both produce the key `payment` and therefore belong to the same slice.
+ *
+ * @property key The captured slice key that identifies this slice.
+ * @property packages The package names that belong to this slice.
+ * @property classes The classes contained in this slice's packages.
+ */
+data class Slice(
+    val key: String,
+    val packages: Set<String>,
+    val classes: List<ClassDeclaration>,
+)

--- a/library/src/main/kotlin/io/github/baole/konture/SlicesRuleBuilder.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/SlicesRuleBuilder.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Octavio Calleya Garcia (@octaviospain)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture
+
+import io.github.baole.konture.core.KontureLogger
+import io.github.baole.konture.core.LogLevel
+import io.github.baole.konture.i18n.getMessage
+import io.github.baole.konture.impl.BaselineManager
+import io.github.baole.konture.impl.PatternMatchers
+import io.github.baole.konture.impl.SliceCycleDetector
+import io.github.baole.konture.impl.SliceGraph
+
+/**
+ * A builder for compiling and verifying architectural rules on slices — groups of packages derived
+ * from a package pattern with a capture group.
+ *
+ * A slice pattern such as `com.acme.(*)..` partitions the matched packages into slices keyed by the
+ * captured segment, and the assertions on [SlicesShould] verify relationships between those slices
+ * (for example, that they are free of cyclic dependencies).
+ */
+@KontureDsl
+class SlicesRuleBuilder(
+    internal val graph: ProjectGraph = Konture.projectGraph,
+    private val sourceSets: SourceSetSelector = SourceSets.production(),
+) {
+    private var pattern: String? = null
+    private val assertions = mutableListOf<(SliceGraph, MutableList<String>) -> Unit>()
+    private var allowEmpty = false
+
+    /**
+     * Sets the slice pattern. It must contain exactly one capture group: `(*)` for one package
+     * segment or `(**)` for one or more segments. The captured text becomes the slice key.
+     */
+    fun matching(pattern: String): SlicesRuleBuilder {
+        this.pattern = pattern
+        return this
+    }
+
+    /**
+     * Configures this builder to allow empty selections (if no packages match the slice pattern the
+     * rule passes instead of throwing an AssertionError).
+     */
+    fun allowEmpty(): SlicesRuleBuilder {
+        allowEmpty = true
+        return this
+    }
+
+    /** Starts adding assertion rules that the derived slices must satisfy. */
+    fun should(): SlicesShould = SlicesShould(this)
+
+    internal fun addShouldAssertion(assertion: (SliceGraph, MutableList<String>) -> Unit) {
+        assertions.add(assertion)
+    }
+
+    /**
+     * Executes the compiled slice rules against the provided project graph.
+     * Throws an [AssertionError] if any rule violations are detected.
+     */
+    fun check(g: ProjectGraph = graph) {
+        val slicePattern = pattern ?: throw AssertionError(getMessage("slices.rule.noPattern"))
+
+        val allClasses =
+            g.getAllModules().flatMap { module ->
+                module.files.flatMap { file ->
+                    if (file.membershipsFor(module.path).any(sourceSets::matches)) file.classes else emptyList()
+                }
+            }.distinctBy { it.fqName to it.filePath }
+
+        val packageToSlice = mutableMapOf<String, String>()
+        val classesByKey = linkedMapOf<String, MutableList<ClassDeclaration>>()
+        val packagesByKey = linkedMapOf<String, MutableSet<String>>()
+        for (cls in allClasses) {
+            val key = PatternMatchers.sliceKeyFor(slicePattern, cls.packageName) ?: continue
+            packageToSlice[cls.packageName] = key
+            classesByKey.getOrPut(key) { mutableListOf() }.add(cls)
+            packagesByKey.getOrPut(key) { mutableSetOf() }.add(cls.packageName)
+        }
+        val slices = classesByKey.keys.sorted().map { Slice(it, packagesByKey.getValue(it), classesByKey.getValue(it)) }
+
+        KontureLogger.log(
+            LogLevel.DEBUG,
+            "Checking Slices Rules: pattern '$slicePattern' produced ${slices.size} slice(s).",
+        )
+        if (slices.isEmpty()) {
+            if (!allowEmpty) {
+                throw AssertionError(getMessage("slices.rule.emptySelect"))
+            } else {
+                KontureLogger.log(
+                    LogLevel.WARNING,
+                    "No packages matched the slice pattern 'matching()'. Rule silently succeeded as allowEmpty is enabled.",
+                )
+                return
+            }
+        }
+
+        if (assertions.isEmpty()) throw AssertionError(getMessage("slices.rule.noAssertion"))
+        val sliceGraph = SliceCycleDetector.buildGraph(slices, packageToSlice, allClasses, slicePattern)
+
+        val runCheck = { list: MutableList<String> -> assertions.forEach { it(sliceGraph, list) } }
+        BaselineManager.checkRule(getMessage("slices.rule.violationHeader"), runCheck)
+    }
+}

--- a/library/src/main/kotlin/io/github/baole/konture/SlicesShould.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/SlicesShould.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Octavio Calleya Garcia (@octaviospain)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture
+
+import io.github.baole.konture.i18n.getMessage
+import io.github.baole.konture.impl.SliceCycleDetector
+
+/**
+ * Assertions that the slices derived by [SlicesRuleBuilder] must satisfy.
+ */
+@KontureDsl
+class SlicesShould(private val builder: SlicesRuleBuilder) {
+    /**
+     * Asserts that the slices have no cyclic dependencies between them. Each detected cycle is
+     * reported as a path, e.g. `payment -> billing -> payment`.
+     */
+    fun beFreeOfCycles(): SlicesRuleBuilder {
+        builder.addShouldAssertion { sliceGraph, violations ->
+            for (cycle in SliceCycleDetector.findCycles(sliceGraph.adjacency)) {
+                val rendered = (cycle + cycle.first()).joinToString(" -> ")
+                violations.add(getMessage("slice.should.beFreeOfCycles", rendered))
+            }
+        }
+        return builder
+    }
+
+    /**
+     * Asserts that no slice depends on any other slice — enforcing complete isolation between them.
+     * Every inter-slice dependency is reported.
+     */
+    fun notDependOnEachOther(): SlicesRuleBuilder {
+        builder.addShouldAssertion { sliceGraph, violations ->
+            for ((from, targets) in sliceGraph.adjacency.toSortedMap()) {
+                for (to in targets.sorted()) {
+                    violations.add(getMessage("slice.should.notDependOnEachOther", from, to))
+                }
+            }
+        }
+        return builder
+    }
+}

--- a/library/src/main/kotlin/io/github/baole/konture/impl/PatternMatchers.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/impl/PatternMatchers.kt
@@ -1,5 +1,6 @@
 /*
- * Copyright 2026 Bao Le Duc
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc, Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,6 +8,7 @@ package io.github.baole.konture.impl
 
 import io.github.baole.konture.core.KontureLogger
 import io.github.baole.konture.core.LogLevel
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Core utility class containing pattern matching algorithms for module glob patterns and package path patterns.
@@ -143,5 +145,68 @@ internal object PatternMatchers {
     ): Boolean {
         val regexString = "^" + pattern.split("*").joinToString(".*") { Regex.escape(it) } + "$"
         return Regex(regexString).matches(input)
+    }
+
+    /**
+     * Derives the slice key for a package from a slice pattern containing a single capture group.
+     *
+     * A slice pattern is a package pattern with exactly one capture token: `(*)` captures one package
+     * segment, `(**)` captures one or more segments. The captured text is the slice key — packages
+     * that produce the same key belong to the same slice. Surrounding `..` behaves as in
+     * [packagePatternToRegex] (zero or more segments).
+     *
+     * For example `"com.acme.(*).."` yields `payment` for `com.acme.payment` and `com.acme.payment.api`,
+     * and `null` for `com.other.thing`.
+     *
+     * @param pattern The slice pattern, which must contain exactly one `(*)` or `(**)` capture token.
+     * @param packageName The package name to derive a slice key from.
+     * @return The captured slice key, or null if the package does not match the pattern.
+     * @throws IllegalArgumentException if the pattern does not contain exactly one capture token.
+     */
+    fun sliceKeyFor(
+        pattern: String,
+        packageName: String,
+    ): String? = sliceRegexFor(pattern).matchEntire(packageName)?.groupValues?.get(1)
+
+    private val sliceRegexCache = ConcurrentHashMap<String, Regex>()
+
+    private fun sliceRegexFor(pattern: String): Regex =
+        sliceRegexCache.getOrPut(pattern) {
+            val doubleStar = pattern.indexOf("(**)")
+            val singleStar = pattern.indexOf("(*)")
+            val (token, captureRegex) =
+                when {
+                    doubleStar != -1 -> "(**)" to "(.+)"
+                    singleStar != -1 -> "(*)" to "([^.]+)"
+                    else -> throw IllegalArgumentException(
+                        "Slice pattern '$pattern' must contain a capture group: '(*)' for one segment or '(**)' for one or more.",
+                    )
+                }
+            val firstIndex = pattern.indexOf(token)
+            require(pattern.indexOf(token, firstIndex + token.length) == -1) {
+                "Slice pattern '$pattern' must contain exactly one capture group."
+            }
+            val left = sliceSideToRegex(pattern.substring(0, firstIndex))
+            val right = sliceSideToRegex(pattern.substring(firstIndex + token.length))
+            Regex("^$left$captureRegex$right$")
+        }
+
+    private fun sliceSideToRegex(side: String): String {
+        val builder = StringBuilder()
+        var i = 0
+        while (i < side.length) {
+            if (side.startsWith("..", i)) {
+                // Trailing '..' matches any suffix; an interior '..' must land on a segment boundary.
+                builder.append(if (i + 2 == side.length) ".*" else "(?:.*\\.)?")
+                i += 2
+            } else if (side[i] == '.') {
+                builder.append("\\.")
+                i += 1
+            } else {
+                builder.append(Regex.escape(side[i].toString()))
+                i += 1
+            }
+        }
+        return builder.toString()
     }
 }

--- a/library/src/main/kotlin/io/github/baole/konture/impl/SliceCycleDetector.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/impl/SliceCycleDetector.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Octavio Calleya Garcia (@octaviospain)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture.impl
+
+import io.github.baole.konture.ClassDeclaration
+import io.github.baole.konture.Slice
+import io.github.baole.konture.collectDependencyPackages
+
+/** The slice dependency graph: the slices and the directed edges between them. */
+internal class SliceGraph(
+    val slices: List<Slice>,
+    val adjacency: Map<String, Set<String>>,
+)
+
+/**
+ * Builds the directed dependency graph between slices and detects cycles within it.
+ *
+ * An edge runs from slice S to slice T when any class in S depends on a package belonging to T,
+ * resolved through the existing source-level dependency resolution. Cycle detection uses the same
+ * depth-first back-edge search as the module-level `assertNoCycles`, but produces deterministic
+ * output — sorted traversal and cycles rotated to start at their smallest key — so recorded
+ * baselines stay stable across runs.
+ */
+internal object SliceCycleDetector {
+    fun buildGraph(
+        slices: List<Slice>,
+        packageToSlice: Map<String, String>,
+        allClasses: List<ClassDeclaration>,
+        slicePattern: String,
+    ): SliceGraph {
+        val sliceKeys = slices.mapTo(mutableSetOf()) { it.key }
+        val adjacency = sortedMapOf<String, MutableSet<String>>()
+        slices.forEach { adjacency[it.key] = sortedSetOf() }
+        for (slice in slices) {
+            for (cls in slice.classes) {
+                for (dependencyPackage in cls.collectDependencyPackages(allClasses)) {
+                    // A dependency package may have no directly-declared classes (e.g. a star import
+                    // of a package whose classes live only in subpackages), so fall back to deriving
+                    // the key from the pattern. Only edges to an actual slice are recorded.
+                    val targetKey =
+                        packageToSlice[dependencyPackage]
+                            ?: PatternMatchers.sliceKeyFor(slicePattern, dependencyPackage)
+                    if (targetKey != null && targetKey != slice.key && targetKey in sliceKeys) {
+                        adjacency.getValue(slice.key).add(targetKey)
+                    }
+                }
+            }
+        }
+        return SliceGraph(slices, adjacency)
+    }
+
+    /**
+     * Returns the distinct cycles in the slice graph. Each cycle is the list of slice keys in
+     * dependency order, rotated to start at the smallest key; render it as `A -> B -> A` by
+     * appending the first key.
+     */
+    fun findCycles(adjacency: Map<String, Set<String>>): List<List<String>> {
+        val visited = mutableSetOf<String>()
+        val stack = mutableListOf<String>()
+        val onStack = mutableSetOf<String>()
+        val cycles = linkedSetOf<List<String>>()
+
+        fun visit(node: String) {
+            visited.add(node)
+            stack.add(node)
+            onStack.add(node)
+            for (next in (adjacency[node] ?: emptySet()).sorted()) {
+                if (next in onStack) {
+                    val start = stack.indexOf(next)
+                    cycles.add(canonicalize(stack.subList(start, stack.size).toList()))
+                } else if (next !in visited) {
+                    visit(next)
+                }
+            }
+            stack.removeAt(stack.size - 1)
+            onStack.remove(node)
+        }
+
+        for (node in adjacency.keys.sorted()) {
+            if (node !in visited) visit(node)
+        }
+        return cycles.toList()
+    }
+
+    private fun canonicalize(cycle: List<String>): List<String> {
+        val minIndex = cycle.indices.minByOrNull { cycle[it] } ?: 0
+        return cycle.subList(minIndex, cycle.size) + cycle.subList(0, minIndex)
+    }
+}

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages.properties
@@ -222,3 +222,10 @@ usage.notCallInPackage={0}call to forbidden package matching ''{1}'' (class ''{2
 usage.notReferenceClassInPackage=reference to forbidden package matching ''{0}'' (class ''{1}'') via ''{2}'' at {3}:{4}
 
 rule.violationCount=Total: {0} violation(s)
+
+slices.rule.violationHeader=Slice architecture violation(s) detected:
+slices.rule.emptySelect=No packages matched the slice pattern in ''matching()''. If this is expected, use ''.allowEmpty()'' or ''allowEmpty = true'' on the rule builder to allow empty selections.
+slices.rule.noAssertion=Slices rule has no assertion (''should()''). You must specify at least one assertion condition.
+slices.rule.noPattern=Slices rule has no pattern (''matching()''). You must specify a package pattern with a capture group, e.g. ''com.acme.(*)..''.
+slice.should.beFreeOfCycles=Slices form a cycle: {0}
+slice.should.notDependOnEachOther=Slice ''{0}'' should not depend on slice ''{1}''

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_es.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_es.properties
@@ -222,3 +222,10 @@ usage.notCallInPackage={0}llamada al paquete prohibido que coincide con ''{1}'' 
 usage.notReferenceClassInPackage=referencia al paquete prohibido que coincide con ''{0}'' (clase ''{1}'') a través de ''{2}'' en {3}:{4}
 
 rule.violationCount=Total: {0} infracción(es)
+
+slices.rule.violationHeader=Se detectaron violación(es) de arquitectura de sección:
+slices.rule.emptySelect=Ningún paquete coincide con el patrón de sección en ''matching()''. Si esto es lo esperado, use ''.allowEmpty()'' o ''allowEmpty = true'' en el rule builder para permitir selecciones vacías.
+slices.rule.noAssertion=La regla de secciones no tiene aserción (''should()''). Debe especificar al menos una condición de aserción.
+slices.rule.noPattern=La regla de secciones no tiene patrón (''matching()''). Debe especificar un patrón de paquete con un grupo de captura, p. ej. ''com.acme.(*)..''.
+slice.should.beFreeOfCycles=Las secciones forman un ciclo: {0}
+slice.should.notDependOnEachOther=La sección ''{0}'' no debería depender de la sección ''{1}''

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_fr.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_fr.properties
@@ -222,3 +222,10 @@ usage.notCallInPackage={0}appel au paquet interdit correspondant à ''{1}'' (cla
 usage.notReferenceClassInPackage=référence au paquet interdit correspondant à ''{0}'' (classe ''{1}'') via ''{2}'' à {3}:{4}
 
 rule.violationCount=Total : {0} violation(s)
+
+slices.rule.violationHeader=Violation(s) d''architecture de tranche détectée(s) :
+slices.rule.emptySelect=Aucun package ne correspond au motif de tranche dans ''matching()''. Si cela est attendu, utilisez ''.allowEmpty()'' ou ''allowEmpty = true'' sur le rule builder pour autoriser les sélections vides.
+slices.rule.noAssertion=La règle de tranches n''a pas d''assertion (''should()''). Vous devez spécifier au moins une condition d''assertion.
+slices.rule.noPattern=La règle de tranches n''a pas de motif (''matching()''). Vous devez spécifier un motif de package avec un groupe de capture, par ex. ''com.acme.(*)..''.
+slice.should.beFreeOfCycles=Les tranches forment un cycle : {0}
+slice.should.notDependOnEachOther=La tranche ''{0}'' ne devrait pas dépendre de la tranche ''{1}''

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_it.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_it.properties
@@ -222,3 +222,10 @@ usage.notCallInPackage={0}chiamata al pacchetto proibito corrispondente a ''{1}'
 usage.notReferenceClassInPackage=riferimento al pacchetto proibito corrispondente a ''{0}'' (classe ''{1}'') via ''{2}'' a {3}:{4}
 
 rule.violationCount=Totale: {0} violazione/i
+
+slices.rule.violationHeader=Rilevata/e violazione/i dell''architettura della sezione:
+slices.rule.emptySelect=Nessun pacchetto corrisponde al pattern di sezione in ''matching()''. Se questo è previsto, usa ''.allowEmpty()'' o ''allowEmpty = true'' nel rule builder per consentire selezioni vuote.
+slices.rule.noAssertion=La regola delle sezioni non ha asserzioni (''should()''). È necessario specificare almeno una condizione di asserzione.
+slices.rule.noPattern=La regola delle sezioni non ha un pattern (''matching()''). È necessario specificare un pattern di pacchetto con un gruppo di cattura, ad es. ''com.acme.(*)..''.
+slice.should.beFreeOfCycles=Le sezioni formano un ciclo: {0}
+slice.should.notDependOnEachOther=La sezione ''{0}'' non dovrebbe dipendere dalla sezione ''{1}''

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_vi.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_vi.properties
@@ -222,3 +222,10 @@ usage.notCallInPackage={0}gọi đến gói bị cấm khớp với ''{1}'' (l�
 usage.notReferenceClassInPackage=tham chiếu đến gói bị cấm khớp với ''{0}'' (lớp ''{1}'') qua ''{2}'' tại {3}:{4}
 
 rule.violationCount=Tổng cộng: {0} vi phạm
+
+slices.rule.violationHeader=Phát hiện vi phạm cấu trúc phần:
+slices.rule.emptySelect=Không có gói nào khớp với mẫu phần trong ''matching()''. Nếu điều này được mong đợi, hãy sử dụng ''.allowEmpty()'' hoặc ''allowEmpty = true'' trên rule builder để cho phép các lựa chọn trống.
+slices.rule.noAssertion=Quy tắc phần không có khẳng định (''should()''). Bạn phải chỉ định ít nhất một điều kiện khẳng định.
+slices.rule.noPattern=Quy tắc phần không có mẫu (''matching()''). Bạn phải chỉ định một mẫu gói có nhóm bắt, ví dụ ''com.acme.(*)..''.
+slice.should.beFreeOfCycles=Các phần tạo thành một chu trình: {0}
+slice.should.notDependOnEachOther=Phần ''{0}'' không nên phụ thuộc vào phần ''{1}''

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_zh.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_zh.properties
@@ -223,3 +223,10 @@ usage.notReferenceClassInPackage=通过 ''{2}'' 引用与禁用的包 ''{0}'' �
 
 
 rule.violationCount=共 {0} 处违规
+
+slices.rule.violationHeader=检测到切片架构违规：
+slices.rule.emptySelect=没有包匹配 ''matching()'' 中的切片模式。如果符合预期，请在 rule builder 中使用 ''.allowEmpty()'' 或 ''allowEmpty = true'' 以允许空选择。
+slices.rule.noAssertion=切片规则没有断言（''should()''）。您必须指定至少一个断言条件。
+slices.rule.noPattern=切片规则没有模式（''matching()''）。您必须指定带捕获组的包模式，例如 ''com.acme.(*)..''。
+slice.should.beFreeOfCycles=切片形成循环：{0}
+slice.should.notDependOnEachOther=切片 ''{0}'' 不应依赖切片 ''{1}''

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_CN.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_CN.properties
@@ -222,3 +222,10 @@ usage.notCallInPackage={0}通过 ''{3}'' 调用与禁用的包 ''{1}'' 匹配的
 usage.notReferenceClassInPackage=通过 ''{2}'' 引用与禁用的包 ''{0}'' 匹配的类 ''{1}''，位于 {3}:{4}
 
 rule.violationCount=共 {0} 处违规
+
+slices.rule.violationHeader=检测到切片架构违规：
+slices.rule.emptySelect=没有包匹配 ''matching()'' 中的切片模式。如果符合预期，请在 rule builder 中使用 ''.allowEmpty()'' 或 ''allowEmpty = true'' 以允许空选择。
+slices.rule.noAssertion=切片规则没有断言（''should()''）。您必须指定至少一个断言条件。
+slices.rule.noPattern=切片规则没有模式（''matching()''）。您必须指定带捕获组的包模式，例如 ''com.acme.(*)..''。
+slice.should.beFreeOfCycles=切片形成循环：{0}
+slice.should.notDependOnEachOther=切片 ''{0}'' 不应依赖切片 ''{1}''

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_TW.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_TW.properties
@@ -221,3 +221,10 @@ usage.notCallInPackage={0}透過 ''{3}'' 呼叫與禁用的套件 ''{1}'' 匹配
 usage.notReferenceClassInPackage=透過 ''{2}'' 參照與禁用的套件 ''{0}'' 匹配的類別 ''{1}''，位於 {3}:{4}
 
 rule.violationCount=共 {0} 處違規
+
+slices.rule.violationHeader=檢測到切片架構違規：
+slices.rule.emptySelect=沒有套件符合 ''matching()'' 中的切片模式。如果符合預期，請在 rule builder 中使用 ''.allowEmpty()'' 或 ''allowEmpty = true'' 以允許空選擇。
+slices.rule.noAssertion=切片規則沒有斷言（''should()''）。您必須指定至少一個斷言條件。
+slices.rule.noPattern=切片規則沒有模式（''matching()''）。您必須指定帶擷取群組的套件模式，例如 ''com.acme.(*)..''。
+slice.should.beFreeOfCycles=切片形成循環：{0}
+slice.should.notDependOnEachOther=切片 ''{0}'' 不應依賴切片 ''{1}''

--- a/library/src/test/kotlin/io/github/baole/konture/SlicesRuleBuilderTest.kt
+++ b/library/src/test/kotlin/io/github/baole/konture/SlicesRuleBuilderTest.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Octavio Calleya Garcia (@octaviospain)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture
+
+import io.github.baole.konture.impl.PatternMatchers
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SlicesRuleBuilderTest {
+    private fun classIn(
+        pkg: String,
+        name: String,
+        imports: List<String> = emptyList(),
+    ) = ClassDeclaration(
+        name = name,
+        fqName = "$pkg.$name",
+        packageName = pkg,
+        isInterface = false,
+        isAbstract = false,
+        annotations = emptyList(),
+        imports = imports,
+        referencedTypes = emptySet(),
+        filePath = "/src/$name.kt",
+    )
+
+    private fun graphOf(vararg classes: ClassDeclaration): ProjectGraph {
+        val files =
+            classes.map {
+                FileDeclaration(it.name + ".kt", it.packageName, classes = listOf(it), filePath = it.filePath)
+            }
+        val module =
+            Module(
+                buildId = ":",
+                path = ":app",
+                projectDir = "app",
+                appliedPlugins = listOf("kotlin"),
+                sourceSets = emptyList(),
+                dependencies = emptyList(),
+                files = files,
+            )
+        return ProjectGraph(mapOf(":" to listOf(module)))
+    }
+
+    @Test
+    fun `beFreeOfCycles detects a package cycle between slices`() {
+        val graph =
+            graphOf(
+                classIn("com.app.a", "ServiceA", imports = listOf("com.app.b.ServiceB")),
+                classIn("com.app.b", "ServiceB", imports = listOf("com.app.a.ServiceA")),
+            )
+        val error =
+            assertThrows(AssertionError::class.java) {
+                SlicesRuleBuilder(graph).matching("com.app.(*)..").should().beFreeOfCycles().check()
+            }
+        assertTrue(error.message!!.contains("Slice architecture violation(s) detected:"))
+        assertTrue(
+            error.message!!.contains("a -> b -> a"),
+            "Expected the cycle path rendered from its smallest key, got: ${error.message}",
+        )
+    }
+
+    @Test
+    fun `beFreeOfCycles passes for acyclic slices`() {
+        val graph =
+            graphOf(
+                classIn("com.app.a", "ServiceA", imports = listOf("com.app.b.ServiceB")),
+                classIn("com.app.b", "ServiceB"),
+            )
+        assertDoesNotThrow {
+            SlicesRuleBuilder(graph).matching("com.app.(*)..").should().beFreeOfCycles().check()
+        }
+    }
+
+    @Test
+    fun `notDependOnEachOther flags an inter-slice dependency`() {
+        val graph =
+            graphOf(
+                classIn("com.app.a", "ServiceA", imports = listOf("com.app.b.ServiceB")),
+                classIn("com.app.b", "ServiceB"),
+            )
+        val error =
+            assertThrows(AssertionError::class.java) {
+                SlicesRuleBuilder(graph).matching("com.app.(*)..").should().notDependOnEachOther().check()
+            }
+        assertTrue(error.message!!.contains("Slice 'a' should not depend on slice 'b'"))
+    }
+
+    @Test
+    fun `notDependOnEachOther passes for isolated slices`() {
+        val graph =
+            graphOf(
+                classIn("com.app.a", "ServiceA"),
+                classIn("com.app.b", "ServiceB"),
+            )
+        assertDoesNotThrow {
+            SlicesRuleBuilder(graph).matching("com.app.(*)..").should().notDependOnEachOther().check()
+        }
+    }
+
+    @Test
+    fun `empty selection throws unless allowEmpty is set`() {
+        val graph = graphOf(classIn("com.app.a", "ServiceA"))
+        assertThrows(AssertionError::class.java) {
+            SlicesRuleBuilder(graph).matching("com.nomatch.(*)..").should().beFreeOfCycles().check()
+        }
+        assertDoesNotThrow {
+            SlicesRuleBuilder(graph).matching("com.nomatch.(*)..").allowEmpty().should().beFreeOfCycles().check()
+        }
+    }
+
+    @Test
+    fun `cycle rendering is deterministic across runs`() {
+        val graph =
+            graphOf(
+                classIn("com.app.a", "ServiceA", imports = listOf("com.app.b.ServiceB")),
+                classIn("com.app.b", "ServiceB", imports = listOf("com.app.a.ServiceA")),
+            )
+
+        fun run(): String =
+            assertThrows(AssertionError::class.java) {
+                SlicesRuleBuilder(graph).matching("com.app.(*)..").should().beFreeOfCycles().check()
+            }.message!!
+        assertEquals(run(), run(), "Cycle violation text must be stable across runs for baseline matching")
+    }
+
+    @Test
+    fun `chained assertions are all evaluated`() {
+        // A cyclic, non-isolated graph: both beFreeOfCycles and notDependOnEachOther should fire,
+        // proving the second should() does not discard the first.
+        val graph =
+            graphOf(
+                classIn("com.app.a", "ServiceA", imports = listOf("com.app.b.ServiceB")),
+                classIn("com.app.b", "ServiceB", imports = listOf("com.app.a.ServiceA")),
+            )
+        val error =
+            assertThrows(AssertionError::class.java) {
+                SlicesRuleBuilder(graph)
+                    .matching("com.app.(*)..")
+                    .should().beFreeOfCycles()
+                    .should().notDependOnEachOther()
+                    .check()
+            }
+        assertTrue(error.message!!.contains("a -> b -> a"), "Expected the cycle assertion to run")
+        assertTrue(
+            error.message!!.contains("should not depend on slice"),
+            "Expected the isolation assertion to run as well",
+        )
+    }
+
+    @Test
+    fun `dependency on a package with classes only in subpackages resolves to its slice`() {
+        // com.app.a depends on package com.app.b (e.g. a star import) whose classes live only in
+        // the subpackage com.app.b.impl. The edge must still resolve to slice 'b'.
+        val graph =
+            graphOf(
+                classIn("com.app.a", "ServiceA", imports = listOf("com.app.b.ServiceB")),
+                classIn("com.app.b.impl", "ServiceB", imports = listOf("com.app.a.ServiceA")),
+            )
+        val error =
+            assertThrows(AssertionError::class.java) {
+                SlicesRuleBuilder(graph).matching("com.app.(*)..").should().beFreeOfCycles().check()
+            }
+        assertTrue(
+            error.message!!.contains("a -> b -> a"),
+            "Expected the cycle through the subpackage-backed slice, got: ${error.message}",
+        )
+    }
+
+    @Test
+    fun `sliceKeyFor captures one segment or many`() {
+        assertEquals("payment", PatternMatchers.sliceKeyFor("com.acme.(*)..", "com.acme.payment"))
+        assertEquals("payment", PatternMatchers.sliceKeyFor("com.acme.(*)..", "com.acme.payment.api"))
+        assertNull(PatternMatchers.sliceKeyFor("com.acme.(*)..", "com.other.thing"))
+        assertNull(PatternMatchers.sliceKeyFor("com.acme.(*)..", "com.acme"))
+        assertEquals("payment.api", PatternMatchers.sliceKeyFor("com.acme.(**)", "com.acme.payment.api"))
+    }
+}


### PR DESCRIPTION
Implements #30.

Adds a `slices()` subject that partitions packages into slices by a package pattern with a capture group, then asserts relationships between those slices — bringing package-level cycle detection to complement the existing module-level `assertNoCycles()`.

```kotlin
Konture.slices()
    .matching("com.acme.(*)..")   // (*) captures one segment, (**) one or more
    .should().beFreeOfCycles()
    .check()

Konture.slices()
    .matching("com.acme.feature.(*)..")
    .should().notDependOnEachOther()
    .check()
```

What it does:

- **`beFreeOfCycles()`** — detects cyclic dependencies between slices and reports each cycle as a path (e.g. `payment -> billing -> payment`). Cycles are rendered deterministically (traversal is sorted and each cycle is rotated to start at its smallest key) so recorded baselines stay stable across runs.
- **`notDependOnEachOther()`** — enforces complete isolation between slices, reporting every inter-slice dependency.
- Available as `Konture.slices()`, a block DSL (`Konture.slices { }`), and inside `architecture { }`, with source-set scoping like the other subjects.

How it fits the existing design:

- Slice edges are resolved through the existing source-level dependency resolution (`collectDependencyPackages`), so no new analysis machinery.
- Cycle detection mirrors the depth-first algorithm and `A -> B -> A` message style of the module-level `assertNoCycles()`.
- The only net-new matching capability is capture-group support (`(*)`/`(**)`) added alongside the existing package matchers, leaving those untouched.
- Slice violations carry no file location (a cycle spans multiple packages), so the baseline stores the full deterministic message; no changes to baseline parsing were needed.

Notes:

- Violation messages are localized across all eight locale bundles. The non-English translations are best-effort and would benefit from native review.
- New keys were added identically to every bundle to satisfy the locale-consistency check.

Testing: new `SlicesRuleBuilderTest` covers cycle detection, acyclic slices, isolation (positive/negative), capture-group key derivation for `(*)` and `(**)`, and empty-selection with/without `allowEmpty()`, plus a determinism assertion for baseline stability. Full `check` passes locally — tests, ktlint, detekt, header validation, and the per-module (80%) and aggregate (84%) coverage gates.