### PR TITLE
Add notBeAccessedByAnyPackage — reverse-access denylist for classes rules

### DIFF
--- a/library/src/main/kotlin/io/github/baole/konture/ClassesShouldDependencyAssertions.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/ClassesShouldDependencyAssertions.kt
@@ -1,5 +1,6 @@
 /*
- * Copyright 2026 Bao Le Duc
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc, Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -68,6 +69,49 @@ internal interface ClassesShouldDependencyAssertions {
      */
     infix fun onlyBeAccessedByAnyPackage(packagePatterns: List<String>): ClassesRuleBuilder =
         onlyBeAccessedByAnyPackage(*packagePatterns.toTypedArray())
+
+    /**
+     * Asserts that selected classes are not accessed by any class residing in packages matching the specified patterns.
+     *
+     * @param packagePatterns Package wildcard patterns representing forbidden accessing classes.
+     */
+    fun notBeAccessedByAnyPackage(vararg packagePatterns: String): ClassesRuleBuilder {
+        builder.setShould { targetCls, allClasses, violations ->
+            val accessingClasses =
+                allClasses.filter { other ->
+                    other.fqName != targetCls.fqName && other.dependsOn(targetCls)
+                }
+            for (accessor in accessingClasses) {
+                val isForbidden =
+                    packagePatterns.any { pattern ->
+                        PatternMatchers.matchesPackage(pattern, accessor.packageName)
+                    }
+                if (isForbidden) {
+                    violations.add(
+                        getMessage(
+                            "class.should.beAccessedByForbiddenPackage",
+                            targetCls.fqName,
+                            accessor.fqName,
+                            accessor.packageName,
+                            packagePatterns.joinToString(),
+                        ),
+                    )
+                }
+            }
+        }
+        return builder
+    }
+
+    /**
+     * Asserts that selected classes are not accessed by any class residing in packages matching the specified pattern.
+     */
+    infix fun notBeAccessedByAnyPackage(packagePattern: String): ClassesRuleBuilder = notBeAccessedByAnyPackage(listOf(packagePattern))
+
+    /**
+     * Asserts that selected classes are not accessed by any class residing in packages matching the specified patterns.
+     */
+    infix fun notBeAccessedByAnyPackage(packagePatterns: List<String>): ClassesRuleBuilder =
+        notBeAccessedByAnyPackage(*packagePatterns.toTypedArray())
 
     /**
      * Asserts that selected classes depend only on classes residing in packages matching the specified patterns.

--- a/library/src/main/kotlin/io/github/baole/konture/KontureScope.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/KontureScope.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -545,6 +545,50 @@ fun List<ClassDeclaration>.assertOnlyBeAccessedByAnyPackage(
 }
 
 /**
+ * Asserts that the selected classes are not accessed by any class residing in packages matching the specified patterns.
+ *
+ * ### Example:
+ * ```kotlin
+ * domainModels.assertNotBeAccessedByAnyPackage("..web..", "..adapter..")
+ * ```
+ *
+ * @param packagePatterns Package wildcard patterns representing forbidden accessing classes.
+ * @param allClasses The complete collection of class declarations used for dependency resolution. Defaults to all classes in the loaded project graph.
+ * @throws AssertionError if any forbidden class accesses any of the target classes.
+ */
+fun List<ClassDeclaration>.assertNotBeAccessedByAnyPackage(
+    vararg packagePatterns: String,
+    allClasses: List<ClassDeclaration> = Konture.projectGraph.getAllModules().flatMap { it.classes },
+) {
+    val violations = mutableListOf<String>()
+    for (targetCls in this) {
+        val accessingClasses =
+            allClasses.filter { other ->
+                other.fqName != targetCls.fqName && other.dependsOn(targetCls)
+            }
+        for (accessor in accessingClasses) {
+            val isForbidden =
+                packagePatterns.any { pattern ->
+                    PatternMatchers.matchesPackage(pattern, accessor.packageName)
+                }
+            if (isForbidden) {
+                violations.add(
+                    "Class ${targetCls.fqName} is accessed by ${accessor.fqName} (in package ${accessor.packageName}), which is forbidden by package pattern(s): ${packagePatterns.joinToString()}",
+                )
+            }
+        }
+    }
+    if (violations.isNotEmpty()) {
+        throw AssertionError(
+            buildString {
+                appendLine("Assertion failed! The following classes violate access rules:")
+                violations.forEach { appendLine("  - $it") }
+            },
+        )
+    }
+}
+
+/**
  * Asserts that the selected classes depend only on classes residing in packages matching the specified patterns.
  *
  * ### Example:
@@ -735,6 +779,18 @@ fun KontureScope.assertOnlyBeAccessedByAnyPackage(
     vararg packagePatterns: String,
     allClasses: List<ClassDeclaration> = Konture.projectGraph.getAllModules().flatMap { it.classes },
 ) = classes.assertOnlyBeAccessedByAnyPackage(*packagePatterns, allClasses = allClasses)
+
+/**
+ * Asserts that the selected classes in the scope are not accessed by any class residing in packages matching the specified patterns.
+ *
+ * @param packagePatterns Package wildcard patterns representing forbidden accessing classes.
+ * @param allClasses The complete collection of class declarations used for dependency resolution. Defaults to all classes in the loaded project graph.
+ * @throws AssertionError if any forbidden class accesses any of the target classes.
+ */
+fun KontureScope.assertNotBeAccessedByAnyPackage(
+    vararg packagePatterns: String,
+    allClasses: List<ClassDeclaration> = Konture.projectGraph.getAllModules().flatMap { it.classes },
+) = classes.assertNotBeAccessedByAnyPackage(*packagePatterns, allClasses = allClasses)
 
 /**
  * Asserts that the selected classes in the scope depend only on classes residing in packages matching the specified patterns.

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages.properties
@@ -33,6 +33,7 @@ class.should.beAssignableToAll=Class {0} should be assignable to all of: {1}, bu
 class.should.beAssignableFrom=Class {0} should be assignable from {1}
 class.should.beDocumented=Class {0} should be documented with a KDoc comment
 class.should.notAccessForbiddenPackage=Class {0} is accessed by {1} (in package {2}), which is not allowed by package pattern(s): {3}
+class.should.beAccessedByForbiddenPackage=Class {0} is accessed by {1} (in package {2}), which is forbidden by package pattern(s): {3}
 class.should.notDependOnForbiddenPackage=Class {0} depends on {1} (in package {2}), which is not allowed by package pattern(s): {3}
 class.should.notDependOnForbiddenPackageExplicit=Class {0} depends on {1} (in package {2}), which is forbidden by package pattern(s): {3}
 class.should.notExposeForbiddenSignature=Class {0} exposes signature type {1} annotated with @{2}, which is forbidden

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_es.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_es.properties
@@ -33,6 +33,7 @@ class.should.beAssignableToAll=La clase {0} debería ser asignable a todos de: {
 class.should.beAssignableFrom=La clase {0} debería ser asignable desde {1}
 class.should.beDocumented=La clase {0} debería estar documentada con un comentario KDoc
 class.should.notAccessForbiddenPackage=La clase {0} es accedida por {1} (en el paquete {2}), lo cual no está permitido por el patrón de paquete(s): {3}
+class.should.beAccessedByForbiddenPackage=La clase {0} es accedida por {1} (en el paquete {2}), lo cual está prohibido por el patrón de paquete(s): {3}
 class.should.notDependOnForbiddenPackage=La clase {0} depende de {1} (en el paquete {2}), lo cual no está permitido por el patrón de paquete(s): {3}
 class.should.notDependOnForbiddenPackageExplicit=La clase {0} depende de {1} (en el paquete {2}), lo cual está prohibido por el patrón de paquete(s): {3}
 class.should.notExposeForbiddenSignature=La clase {0} expone el tipo de firma {1} anotado con @{2}, lo cual está prohibido

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_fr.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_fr.properties
@@ -33,6 +33,7 @@ class.should.beAssignableToAll=La classe {0} devrait être assignable à tous le
 class.should.beAssignableFrom=La classe {0} devrait être assignable depuis {1}
 class.should.beDocumented=La classe {0} devrait être documentée avec un commentaire KDoc
 class.should.notAccessForbiddenPackage=La classe {0} est accédée par {1} (dans le package {2}), ce qui n''est pas autorisé par les motifs de package : {3}
+class.should.beAccessedByForbiddenPackage=La classe {0} est accédée par {1} (dans le package {2}), ce qui est interdit par les motifs de package : {3}
 class.should.notDependOnForbiddenPackage=La classe {0} dépend de {1} (dans le package {2}), ce qui n''est pas autorisé par les motifs de package : {3}
 class.should.notDependOnForbiddenPackageExplicit=La classe {0} dépend de {1} (dans le package {2}), ce qui est interdit par les motifs de package : {3}
 class.should.notExposeForbiddenSignature=La classe {0} expose le type de signature {1} annoté de @{2}, ce qui est interdit

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_it.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_it.properties
@@ -33,6 +33,7 @@ class.should.beAssignableToAll=La classe {0} dovrebbe essere assegnabile a tutti
 class.should.beAssignableFrom=La classe {0} dovrebbe essere assegnabile da {1}
 class.should.beDocumented=La classe {0} dovrebbe essere documentata con un commento KDoc
 class.should.notAccessForbiddenPackage=La classe {0} è acceduta da {1} (nel package {2}), il che non è consentito dal pattern del package: {3}
+class.should.beAccessedByForbiddenPackage=La classe {0} è acceduta da {1} (nel package {2}), il che è vietato dal pattern del package: {3}
 class.should.notDependOnForbiddenPackage=La classe {0} dipende da {1} (nel package {2}), il che non è consentito dal pattern del package: {3}
 class.should.notDependOnForbiddenPackageExplicit=La classe {0} dipende da {1} (nel package {2}), il che è vietato dal pattern del package: {3}
 class.should.notExposeForbiddenSignature=La classe {0} espone il tipo di firma {1} annotato con @{2}, il che è vietato

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_vi.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_vi.properties
@@ -33,6 +33,7 @@ class.should.beAssignableToAll=Lớp {0} phải có thể gán được cho tấ
 class.should.beAssignableFrom=Lớp {0} phải có thể gán được từ {1}
 class.should.beDocumented=Lớp {0} phải được viết tài liệu bằng chú thích KDoc
 class.should.notAccessForbiddenPackage=Lớp {0} bị truy cập bởi {1} (trong gói {2}), điều này không được phép bởi mẫu gói: {3}
+class.should.beAccessedByForbiddenPackage=Lớp {0} bị truy cập bởi {1} (trong gói {2}), điều này bị cấm bởi mẫu gói: {3}
 class.should.notDependOnForbiddenPackage=Lớp {0} phụ thuộc vào {1} (trong gói {2}), điều này không được phép bởi mẫu gói: {3}
 class.should.notDependOnForbiddenPackageExplicit=Lớp {0} phụ thuộc vào {1} (trong gói {2}), điều này bị cấm bởi mẫu gói: {3}
 class.should.notExposeForbiddenSignature=Lớp {0} để lộ kiểu chữ ký {1} được chú thích với @{2}, điều này bị cấm

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_zh.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_zh.properties
@@ -33,6 +33,7 @@ class.should.beAssignableToAll=类 {0} 应该可以分配给以下所有类型�
 class.should.beAssignableFrom=类 {0} 应该可以自 {1} 分配
 class.should.beDocumented=类 {0} 应该带有 KDoc 注释文档
 class.should.notAccessForbiddenPackage=类 {0} 被 {1}（位于包 {2} 中）访问，这不符合包模式要求：{3}
+class.should.beAccessedByForbiddenPackage=类 {0} 被 {1}（位于包 {2} 中）访问，这被包模式禁止：{3}
 class.should.notDependOnForbiddenPackage=类 {0} 依赖于 {1}（位于包 {2} 中），这不符合包模式要求：{3}
 class.should.notDependOnForbiddenPackageExplicit=类 {0} 依赖于 {1}（位于包 {2} 中），这被包模式禁止：{3}
 class.should.notExposeForbiddenSignature=类 {0} 暴露了带有 @{2} 注解的签名类型 {1}，这是被禁止的

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_CN.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_CN.properties
@@ -33,6 +33,7 @@ class.should.beAssignableToAll=类 {0} 应该可以分配给以下所有类型�
 class.should.beAssignableFrom=类 {0} 应该可以自 {1} 分配
 class.should.beDocumented=类 {0} 应该带有 KDoc 注释文档
 class.should.notAccessForbiddenPackage=类 {0} 被 {1}（位于包 {2} 中）访问，这不符合包模式要求：{3}
+class.should.beAccessedByForbiddenPackage=类 {0} 被 {1}（位于包 {2} 中）访问，这被包模式禁止：{3}
 class.should.notDependOnForbiddenPackage=类 {0} 依赖于 {1}（位于包 {2} 中），这不符合包模式要求：{3}
 class.should.notDependOnForbiddenPackageExplicit=类 {0} 依赖于 {1}（位于包 {2} 中），这被包模式禁止：{3}
 class.should.notExposeForbiddenSignature=类 {0} 暴露了带有 @{2} 注解的签名类型 {1}，这是被禁止的

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_TW.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_TW.properties
@@ -33,6 +33,7 @@ class.should.beAssignableToAll=類別 {0} 應該可以分配給以下所有型�
 class.should.beAssignableFrom=類別 {0} 應該可以自 {1} 分配
 class.should.beDocumented=類別 {0} 應該帶有 KDoc 註解文件
 class.should.notAccessForbiddenPackage=類別 {0} 被 {1}（位於套件 {2} 中）存取，這不符合套件模式要求：{3}
+class.should.beAccessedByForbiddenPackage=類別 {0} 被 {1}（位於套件 {2} 中）存取，這被套件模式禁止：{3}
 class.should.notDependOnForbiddenPackage=類別 {0} 依賴於 {1}（位於套件 {2} 中），這不符合套件模式要求：{3}
 class.should.notDependOnForbiddenPackageExplicit=類別 {0} 依賴於 {1}（位於套件 {2} 中），這被套件模式禁止：{3}
 class.should.notExposeForbiddenSignature=類別 {0} 暴露了帶有 @{2} 註解的簽名型態 {1}，這是被禁止的

--- a/library/src/test/kotlin/io/github/baole/konture/ClassesShouldTest.kt
+++ b/library/src/test/kotlin/io/github/baole/konture/ClassesShouldTest.kt
@@ -1,5 +1,6 @@
 /*
- * Copyright 2026 Bao Le Duc
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc, Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -1011,6 +1012,66 @@ class ClassesShouldTest : RuleBuildersTestBase() {
         assertProp(classWithProp, emptyList(), vPr)
         assertEquals(1, vPr.size)
         assertTrue(vPr[0].contains("Property myProp in class com.test.TestClass has violations"))
+    }
+
+    @Test
+    fun `test classes notBeAccessedByAnyPackage flags accessors in forbidden packages`() {
+        fun builder() = ClassesRuleBuilder(projectGraph)
+
+        val target =
+            ClassDeclaration(
+                name = "DomainModel",
+                fqName = "com.acme.domain.DomainModel",
+                packageName = "com.acme.domain",
+                isInterface = false,
+                isAbstract = false,
+                annotations = emptyList(),
+                imports = emptyList(),
+                referencedTypes = emptySet(),
+                filePath = "/src/DomainModel.kt",
+            )
+        val forbiddenAccessor =
+            ClassDeclaration(
+                name = "WebController",
+                fqName = "com.acme.web.WebController",
+                packageName = "com.acme.web",
+                isInterface = false,
+                isAbstract = false,
+                annotations = emptyList(),
+                imports = listOf("com.acme.domain.DomainModel"),
+                referencedTypes = setOf("com.acme.domain.DomainModel"),
+                filePath = "/src/WebController.kt",
+            )
+        val allowedAccessor =
+            ClassDeclaration(
+                name = "DomainService",
+                fqName = "com.acme.domain.DomainService",
+                packageName = "com.acme.domain",
+                isInterface = false,
+                isAbstract = false,
+                annotations = emptyList(),
+                imports = listOf("com.acme.domain.DomainModel"),
+                referencedTypes = setOf("com.acme.domain.DomainModel"),
+                filePath = "/src/DomainService.kt",
+            )
+
+        // An accessor residing in a forbidden package produces one violation
+        val assertForbidden = builder().should().notBeAccessedByAnyPackage("..web..").getShouldAssertion()!!
+        val vForbidden = mutableListOf<String>()
+        assertForbidden(target, listOf(target, forbiddenAccessor, allowedAccessor), vForbidden)
+        assertEquals(1, vForbidden.size)
+
+        // Only an allowed accessor present: no violation
+        val assertClean = builder().should().notBeAccessedByAnyPackage("..web..").getShouldAssertion()!!
+        val vClean = mutableListOf<String>()
+        assertClean(target, listOf(target, allowedAccessor), vClean)
+        assertTrue(vClean.isEmpty())
+
+        // No accessors at all: vacuous pass, consistent with the forward assertions
+        val assertVacuous = builder().should().notBeAccessedByAnyPackage("..web..").getShouldAssertion()!!
+        val vVacuous = mutableListOf<String>()
+        assertVacuous(target, listOf(target), vVacuous)
+        assertTrue(vVacuous.isEmpty())
     }
 
     @Test

--- a/library/src/test/kotlin/io/github/baole/konture/KontureScopeHighLevelAssertionsTest.kt
+++ b/library/src/test/kotlin/io/github/baole/konture/KontureScopeHighLevelAssertionsTest.kt
@@ -1,5 +1,6 @@
 /*
- * Copyright 2026 Bao Le Duc
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc, Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -310,6 +311,58 @@ internal class KontureScopeHighLevelAssertionsTest : KontureScopeTestFixture() {
             )
         assertThrows<AssertionError> {
             listOf(classWithExternalLib).assertOnlyDependOnClassesInAnyPackage("..example..", allClasses = listOf(classWithExternalLib))
+        }
+    }
+
+    @Test
+    fun `test High-level notBeAccessedByAnyPackage denylist assertion`() {
+        val domainModel =
+            ClassDeclaration(
+                name = "DomainModel",
+                fqName = "com.example.domain.DomainModel",
+                packageName = "com.example.domain",
+                isInterface = false,
+                isAbstract = false,
+                annotations = emptyList(),
+                imports = emptyList(),
+                referencedTypes = emptySet(),
+                filePath = "/src/DomainModel.kt",
+            )
+        val domainService =
+            ClassDeclaration(
+                name = "DomainService",
+                fqName = "com.example.domain.DomainService",
+                packageName = "com.example.domain",
+                isInterface = false,
+                isAbstract = false,
+                annotations = emptyList(),
+                imports = listOf("com.example.domain.DomainModel"),
+                referencedTypes = setOf("com.example.domain.DomainModel"),
+                filePath = "/src/DomainService.kt",
+            )
+        val webController =
+            ClassDeclaration(
+                name = "WebController",
+                fqName = "com.example.web.WebController",
+                packageName = "com.example.web",
+                isInterface = false,
+                isAbstract = false,
+                annotations = emptyList(),
+                imports = listOf("com.example.domain.DomainModel"),
+                referencedTypes = setOf("com.example.domain.DomainModel"),
+                filePath = "/src/WebController.kt",
+            )
+
+        // Accessed only by a same-layer service: passes on both receivers
+        listOf(domainModel).assertNotBeAccessedByAnyPackage("..web..", allClasses = listOf(domainModel, domainService))
+        KontureScope(listOf(domainModel)).assertNotBeAccessedByAnyPackage("..web..", allClasses = listOf(domainModel, domainService))
+
+        // Accessed by a forbidden layer: fails on both receivers
+        assertThrows<AssertionError> {
+            listOf(domainModel).assertNotBeAccessedByAnyPackage("..web..", allClasses = listOf(domainModel, webController))
+        }
+        assertThrows<AssertionError> {
+            KontureScope(listOf(domainModel)).assertNotBeAccessedByAnyPackage("..web..", allClasses = listOf(domainModel, webController))
         }
     }
 }


### PR DESCRIPTION
Closes #36.

## Problem

The classes DSL had full symmetry for *forward* dependencies but only half of it for *reverse* access:

| Direction | Allowlist (`only…`) | Denylist (`not…`) |
|---|---|---|
| Forward (`dependOn`) | `onlyDependOnClassesInAnyPackage` ✅ | `notDependOnClassesInAnyPackage` ✅ |
| Reverse (`beAccessedBy`) | `onlyBeAccessedByAnyPackage` ✅ | **was missing** ❌ |

There was no way to express the common encapsulation rule "these classes must **not** be accessed by classes in package X" without inverting the whole thing into an allowlist.

## Change

Adds `notBeAccessedByAnyPackage`, the denylist counterpart to `onlyBeAccessedByAnyPackage`:

```kotlin
classes()
    .that().resideInAPackage("..domain..")
    .should().notBeAccessedByAnyPackage("..web..", "..adapter..")
    .check()
```

- `notBeAccessedByAnyPackage` on the classes rule builder (`vararg`, single-`infix`, and `List` overloads), symmetric to `onlyBeAccessedByAnyPackage`.
- `assertNotBeAccessedByAnyPackage` fluent forms on `List<ClassDeclaration>` and `KontureScope`.
- New localized message `class.should.beAccessedByForbiddenPackage` added to every locale bundle (en/fr/es/it/vi/zh/zh-CN/zh-TW) with English fallback.
- Reuses the existing `dependsOn` access edge — no new notion of "access". A selected class with no accessors passes vacuously, consistent with the forward assertions.

## Testing

- `./gradlew :library:test` passes; new tests cover: an accessor in a forbidden package producing a violation, an allowed-only accessor passing, and the no-accessor vacuous pass. The fluent form is exercised on both the `List` and `KontureScope` receivers.
- `./gradlew :library:detekt` clean; `spotlessApply` applied.

The recommended direction from the issue is implemented here. The predicate-based alternative (`onlyBeAccessedByClassesThat { … }`) is left out; happy to follow up if you'd prefer that route too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
