### PR TITLE
First-Class Architectural Layers & architecturePolicy DSL (#69)

### DIFF
--- a/library/api/library.api
+++ b/library/api/library.api
@@ -31,6 +31,19 @@ public final class io/github/baole/konture/ArchitectureKt {
 	public static final fun architecture (Lkotlin/jvm/functions/Function1;)V
 }
 
+public final class io/github/baole/konture/ArchitectureLayerPolicy {
+	public final fun getName ()Ljava/lang/String;
+	public final fun mayBeAccessedBy (Ljava/util/List;)V
+	public final fun mayBeAccessedBy ([Ljava/lang/String;)V
+	public final fun mayDependOn (Ljava/util/List;)V
+	public final fun mayDependOn ([Ljava/lang/String;)V
+	public final fun mustNotBeAccessedBy (Ljava/util/List;)V
+	public final fun mustNotBeAccessedBy ([Ljava/lang/String;)V
+	public final fun mustNotDependOn (Ljava/util/List;)V
+	public final fun mustNotDependOn ([Ljava/lang/String;)V
+	public final fun selector (Lkotlin/jvm/functions/Function1;)V
+}
+
 public final class io/github/baole/konture/ClassDeclaration {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/List;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Lio/github/baole/konture/Visibility;Ljava/util/Set;Ljava/util/List;Lio/github/baole/konture/ConstructorDeclaration;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/baole/konture/ClassDeclaration;Ljava/lang/String;Ljava/util/Map;ZI)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/List;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Lio/github/baole/konture/Visibility;Ljava/util/Set;Ljava/util/List;Lio/github/baole/konture/ConstructorDeclaration;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/baole/konture/ClassDeclaration;Ljava/lang/String;Ljava/util/Map;ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -3394,6 +3407,7 @@ public final class io/github/baole/konture/KontureContext {
 	public final fun getFunctions ()Lio/github/baole/konture/KontureFunctionScope;
 	public final fun getModules ()Lio/github/baole/konture/KontureModuleScope;
 	public final fun getProperties ()Lio/github/baole/konture/KonturePropertyScope;
+	public final fun layer (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public final fun layered (Lkotlin/jvm/functions/Function1;)V
 	public final fun layeredArchitecture (Lkotlin/jvm/functions/Function1;)V
 	public final fun modules (Lkotlin/jvm/functions/Function1;)V
@@ -3757,6 +3771,13 @@ public final class io/github/baole/konture/KontureSliceScopeKt {
 
 public final class io/github/baole/konture/KontureTypeReferenceKt {
 	public static final fun konturePackageName (Lkotlin/reflect/KClass;)Ljava/lang/String;
+}
+
+public final class io/github/baole/konture/LayerSelectorDsl {
+	public final fun modules (Ljava/util/List;)V
+	public final fun modules ([Ljava/lang/String;)V
+	public final fun packages (Ljava/util/List;)V
+	public final fun packages ([Ljava/lang/String;)V
 }
 
 public final class io/github/baole/konture/LayeredArchitectureBuilder {

--- a/library/src/main/kotlin/io/github/baole/konture/ArchitectureLayerPolicy.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/ArchitectureLayerPolicy.kt
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture
+
+import io.github.baole.konture.core.model.Severity
+import io.github.baole.konture.core.model.Subject
+import io.github.baole.konture.core.model.Violation
+import io.github.baole.konture.i18n.getMessage
+import io.github.baole.konture.impl.BaselineManager
+import io.github.baole.konture.impl.KontureRuntimeStateProvider
+import io.github.baole.konture.impl.PatternMatchers
+import io.github.baole.konture.impl.ViolationLocation
+
+/**
+ * First-class, declarative architectural-layer policy DSL.
+ *
+ * A layer groups a set of modules and/or packages and declares which other
+ * layers it may (or may not) depend on, and which layers may (or may not) depend
+ * on it. The policy is compiled down to the primitive Konture module/package
+ * selectors and class dependency assertions.
+ *
+ * ### Example Usage:
+ * ```kotlin
+ * architecture {
+ *     layer("feature") {
+ *         selector {
+ *             modules(":feature:**")
+ *         }
+ *         mayDependOn("core", "domain")
+ *         mustNotDependOn("feature")
+ *     }
+ *
+ *     layer("domain") {
+ *         selector {
+ *             packages("com.acme.domain..")
+ *         }
+ *         mayDependOn("core")
+ *     }
+ * }
+ * ```
+ */
+@KontureDsl
+public class ArchitectureLayerPolicy internal constructor(
+    /** The unique, human-readable name of this layer. */
+    public val name: String,
+) {
+    private val selector = LayerSelectorDsl()
+
+    private var mayDependOnConfig: Set<String> = emptySet()
+    private var mayDependOnConfigured = false
+    private var mustNotDependOnConfig: Set<String> = emptySet()
+    private var mustNotDependOnConfigured = false
+    private var mayBeAccessedByConfig: Set<String> = emptySet()
+    private var mayBeAccessedByConfigured = false
+    private var mustNotBeAccessedByConfig: Set<String> = emptySet()
+    private var mustNotBeAccessedByConfigured = false
+
+    /**
+     * Declares which modules and/or packages belong to this layer.
+     *
+     * - [LayerSelectorDsl.modules] accepts module glob patterns (e.g. `":feature:**"`).
+     * - [LayerSelectorDsl.packages] accepts package patterns (e.g. `"com.acme.feature.."`).
+     */
+    public fun selector(block: LayerSelectorDsl.() -> Unit) {
+        selector.apply(block)
+    }
+
+    /** Restricts the layers this layer is allowed to depend on (intra-layer dependencies are always allowed). */
+    public fun mayDependOn(vararg layers: String) {
+        mayDependOnConfig = layers.toSet()
+        mayDependOnConfigured = true
+    }
+
+    /** Restricts the layers this layer is allowed to depend on. */
+    public fun mayDependOn(layers: List<String>): Unit = mayDependOn(*layers.toTypedArray())
+
+    /** Forbids this layer from depending on the given layers. */
+    public fun mustNotDependOn(vararg layers: String) {
+        mustNotDependOnConfig = layers.toSet()
+        mustNotDependOnConfigured = true
+    }
+
+    /** Forbids this layer from depending on the given layers. */
+    public fun mustNotDependOn(layers: List<String>): Unit = mustNotDependOn(*layers.toTypedArray())
+
+    /** Restricts the layers that are allowed to depend on this layer (intra-layer dependencies are always allowed). */
+    public fun mayBeAccessedBy(vararg layers: String) {
+        mayBeAccessedByConfig = layers.toSet()
+        mayBeAccessedByConfigured = true
+    }
+
+    /** Restricts the layers that are allowed to depend on this layer. */
+    public fun mayBeAccessedBy(layers: List<String>): Unit = mayBeAccessedBy(*layers.toTypedArray())
+
+    /** Forbids the given layers from depending on this layer. */
+    public fun mustNotBeAccessedBy(vararg layers: String) {
+        mustNotBeAccessedByConfig = layers.toSet()
+        mustNotBeAccessedByConfigured = true
+    }
+
+    /** Forbids the given layers from depending on this layer. */
+    public fun mustNotBeAccessedBy(layers: List<String>): Unit = mustNotBeAccessedBy(*layers.toTypedArray())
+
+    internal fun selectorSnapshot(): SelectorSnapshot = selector.snapshot()
+
+    internal fun mayDependOnConfig(): Set<String> = mayDependOnConfig
+
+    internal fun hasMayDependOn(): Boolean = mayDependOnConfigured
+
+    internal fun mustNotDependOnConfig(): Set<String> = mustNotDependOnConfig
+
+    internal fun hasMustNotDependOn(): Boolean = mustNotDependOnConfigured
+
+    internal fun mayBeAccessedByConfig(): Set<String> = mayBeAccessedByConfig
+
+    internal fun hasMayBeAccessedBy(): Boolean = mayBeAccessedByConfigured
+
+    internal fun mustNotBeAccessedByConfig(): Set<String> = mustNotBeAccessedByConfig
+
+    internal fun hasMustNotBeAccessedBy(): Boolean = mustNotBeAccessedByConfigured
+
+    internal fun referencedLayerNames(): Set<String> =
+        buildSet {
+            if (mayDependOnConfigured) addAll(mayDependOnConfig)
+            if (mustNotDependOnConfigured) addAll(mustNotDependOnConfig)
+            if (mayBeAccessedByConfigured) addAll(mayBeAccessedByConfig)
+            if (mustNotBeAccessedByConfigured) addAll(mustNotBeAccessedByConfig)
+        }
+}
+
+/**
+ * Selector DSL used within [ArchitectureLayerPolicy.selector] to define a layer's
+ * member modules and/or packages.
+ */
+@KontureDsl
+public class LayerSelectorDsl internal constructor() {
+    private val modulePatterns = mutableListOf<String>()
+    private val packagePatterns = mutableListOf<String>()
+
+    /** Adds module glob patterns (e.g. `":feature:**"`) that select member modules. */
+    public fun modules(vararg patterns: String) {
+        modulePatterns += patterns
+    }
+
+    /** Adds module glob patterns that select member modules. */
+    public fun modules(patterns: List<String>): Unit = modules(*patterns.toTypedArray())
+
+    /** Adds package patterns (e.g. `"com.acme.feature.."`) that select member classes. */
+    public fun packages(vararg patterns: String) {
+        packagePatterns += patterns
+    }
+
+    /** Adds package patterns that select member classes. */
+    public fun packages(patterns: List<String>): Unit = packages(*patterns.toTypedArray())
+
+    internal fun snapshot(): SelectorSnapshot = SelectorSnapshot(modulePatterns.toList(), packagePatterns.toList())
+}
+
+/** Immutable snapshot of the selector patterns declared for a layer. */
+internal data class SelectorSnapshot(
+    val modulePatterns: List<String>,
+    val packagePatterns: List<String>,
+)
+
+/**
+ * Resolves the declared [ArchitectureLayerPolicy] definitions against the live project
+ * graph and reports violations on the configured dependency boundaries.
+ */
+internal class ArchitectureLayerRegistry(
+    private val policies: List<ArchitectureLayerPolicy>,
+    private val allModules: List<Module>,
+    private val allClasses: List<ClassDeclaration>,
+) {
+    private val memberClassesByName: Map<String, List<ClassDeclaration>>
+    private val layersByClassFqName: Map<String, Set<String>>
+
+    init {
+        val byName = policies.associate { it.name to it.resolveMembership() }
+        validateReferencedLayerNames(byName.keys)
+        memberClassesByName = byName
+        val reverse = mutableMapOf<String, MutableSet<String>>()
+        for ((layerName, classes) in byName) {
+            for (cls in classes) reverse.getOrPut(cls.fqName) { mutableSetOf() }.add(layerName)
+        }
+        layersByClassFqName = reverse.mapValues { it.value.toSet() }
+    }
+
+    /**
+     * Rejects references to layer names that were never declared, so a typo in a
+     * `mayDependOn(...)`/`mustNotDependOn(...)`/`mayBeAccessedBy(...)`/
+     * `mustNotBeAccessedBy(...)` cannot silently produce a rule that never fires.
+     */
+    private fun validateReferencedLayerNames(declared: Set<String>) {
+        val referenced =
+            policies.flatMap { policy ->
+                policy.referencedLayerNames()
+            }.toSet()
+        val unknown = (referenced - declared).sorted()
+        require(unknown.isEmpty()) {
+            getMessage("architecture.policy.undefinedLayer", unknown.joinToString())
+        }
+    }
+
+    /** Compiles a layer down to the set of member classes selected by its module and package patterns. */
+    private fun ArchitectureLayerPolicy.resolveMembership(): List<ClassDeclaration> {
+        val snapshot = selectorSnapshot()
+        require(snapshot.modulePatterns.isNotEmpty() || snapshot.packagePatterns.isNotEmpty()) {
+            getMessage("architecture.policy.noSelector", name)
+        }
+        val fromModules =
+            snapshot.modulePatterns
+                .flatMap { pattern -> allModules.filter { PatternMatchers.matchesModuleGlob(pattern, it.path) } }
+                .flatMap { it.classes }
+        val fromPackages =
+            if (snapshot.packagePatterns.isNotEmpty()) {
+                allClasses.filter { cls ->
+                    snapshot.packagePatterns.any { PatternMatchers.matchesPackage(it, cls.packageName) }
+                }
+            } else {
+                emptyList()
+            }
+        return (fromModules + fromPackages).distinctBy { it.fqName }
+    }
+
+    /** Collects all boundary violations for every declared layer into [out]. */
+    public fun collectViolations(out: MutableList<Violation>) {
+        for (policy in policies) {
+            policy.collectForLayer(out)
+        }
+    }
+
+    private fun ArchitectureLayerPolicy.collectForLayer(out: MutableList<Violation>) {
+        val members = memberClassesByName[name].orEmpty()
+        checkOutboundConstraints(members, out)
+        checkInboundConstraints(members, out)
+    }
+
+    /** Verifies the outbound (depends-on) boundaries declared by [this] layer. */
+    private fun ArchitectureLayerPolicy.checkOutboundConstraints(
+        members: List<ClassDeclaration>,
+        out: MutableList<Violation>,
+    ) {
+        if (!hasMayDependOn() && !hasMustNotDependOn()) return
+        val allowed = mayDependOnConfig().takeIf { hasMayDependOn() }
+        val forbidden = mustNotDependOnConfig().takeIf { hasMustNotDependOn() }
+        for (source in members) {
+            for (target in allClasses) {
+                if (!source.dependsOn(target)) continue
+                if (allowed != null) {
+                    checkMayDependOn(source, target, allowed, out)
+                }
+                if (forbidden != null) {
+                    checkMustNotDependOn(source, target, forbidden, out)
+                }
+            }
+        }
+    }
+
+    /** Verifies the inbound (accessed-by) boundaries declared by [this] layer. */
+    private fun ArchitectureLayerPolicy.checkInboundConstraints(
+        members: List<ClassDeclaration>,
+        out: MutableList<Violation>,
+    ) {
+        if (!hasMayBeAccessedBy() && !hasMustNotBeAccessedBy()) return
+        val allowed = mayBeAccessedByConfig().takeIf { hasMayBeAccessedBy() }
+        val forbidden = mustNotBeAccessedByConfig().takeIf { hasMustNotBeAccessedBy() }
+        for (target in members) {
+            for (caller in allClasses) {
+                if (!caller.dependsOn(target)) continue
+                if (allowed != null) {
+                    checkMayBeAccessedBy(target, caller, allowed, out)
+                }
+                if (forbidden != null) {
+                    checkMustNotBeAccessedBy(target, caller, forbidden, out)
+                }
+            }
+        }
+    }
+
+    private fun ArchitectureLayerPolicy.checkMayDependOn(
+        source: ClassDeclaration,
+        target: ClassDeclaration,
+        allowed: Set<String>,
+        out: MutableList<Violation>,
+    ) {
+        val illegal = layersByClassFqName[target.fqName].orEmpty().filter { it != name && it !in allowed }
+        if (illegal.isEmpty()) return
+        out.add(
+            newViolation(
+                "architecture.policy.mayDependOn",
+                name,
+                allowed.joinToString(),
+                source.fqName,
+                target.fqName,
+                illegal.joinToString(),
+                ViolationLocation.format(source),
+            ),
+        )
+    }
+
+    private fun ArchitectureLayerPolicy.checkMustNotDependOn(
+        source: ClassDeclaration,
+        target: ClassDeclaration,
+        forbidden: Set<String>,
+        out: MutableList<Violation>,
+    ) {
+        val hit = targetLayers(target).any { it in forbidden }
+        if (!hit) return
+        out.add(
+            newViolation(
+                "architecture.policy.mustNotDependOn",
+                name,
+                forbidden.joinToString(),
+                source.fqName,
+                target.fqName,
+                targetLayers(target).joinToString(),
+                ViolationLocation.format(source),
+            ),
+        )
+    }
+
+    private fun ArchitectureLayerPolicy.checkMayBeAccessedBy(
+        target: ClassDeclaration,
+        caller: ClassDeclaration,
+        allowed: Set<String>,
+        out: MutableList<Violation>,
+    ) {
+        val illegal = layersByClassFqName[caller.fqName].orEmpty().filter { it != name && it !in allowed }
+        if (illegal.isEmpty()) return
+        out.add(
+            newViolation(
+                "architecture.policy.mayBeAccessedBy",
+                name,
+                allowed.joinToString(),
+                caller.fqName,
+                illegal.joinToString(),
+                target.fqName,
+                ViolationLocation.format(caller),
+            ),
+        )
+    }
+
+    private fun ArchitectureLayerPolicy.checkMustNotBeAccessedBy(
+        target: ClassDeclaration,
+        caller: ClassDeclaration,
+        forbidden: Set<String>,
+        out: MutableList<Violation>,
+    ) {
+        val hit = layersByClassFqName[caller.fqName].orEmpty().any { it in forbidden }
+        if (!hit) return
+        out.add(
+            newViolation(
+                "architecture.policy.mustNotBeAccessedBy",
+                name,
+                forbidden.joinToString(),
+                caller.fqName,
+                targetLayers(caller).joinToString(),
+                target.fqName,
+                ViolationLocation.format(caller),
+            ),
+        )
+    }
+
+    private fun targetLayers(cls: ClassDeclaration): Set<String> = layersByClassFqName[cls.fqName].orEmpty()
+
+    private fun newViolation(
+        messageKey: String,
+        vararg args: Any?,
+    ): Violation {
+        val currentMeta = KontureRuntimeStateProvider.currentState.currentRuleMetadata
+        return Violation(
+            ruleId = currentMeta?.id ?: "architecture.policy",
+            subject = Subject.CustomSubject(name = "Architecture Policy"),
+            message = getMessage(messageKey, *args),
+            severity = currentMeta?.severity ?: Severity.ERROR,
+            metadata = currentMeta,
+        )
+    }
+}
+
+/**
+ * Runs all declared [ArchitectureLayerPolicy] definitions against [graph], reporting
+ * violations through the baseline-aware [BaselineManager] and throwing on any that
+ * exceed the configured fail-on-severity threshold.
+ */
+internal fun checkLayerPolicies(
+    policies: List<ArchitectureLayerPolicy>,
+    graph: ProjectGraph,
+) {
+    if (policies.isEmpty()) return
+    val allModules = graph.getAllModules()
+    val allClasses = allModules.flatMap { it.classes }
+    val currentMeta = KontureRuntimeStateProvider.currentState.currentRuleMetadata
+    val ruleId = currentMeta?.id ?: "architecture.policy"
+    val header = currentMeta?.description ?: getMessage("architecture.policy.violationHeader")
+    BaselineManager.checkRuleReport(
+        ruleId = ruleId,
+        violationHeader = header,
+        runCheckReport = { violations ->
+            ArchitectureLayerRegistry(policies, allModules, allClasses).collectViolations(violations)
+        },
+    )
+}

--- a/library/src/main/kotlin/io/github/baole/konture/KontureContext.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/KontureContext.kt
@@ -26,6 +26,8 @@ public class KontureContext(
 
     private val ruleSuites = mutableListOf<RuleSuite>()
 
+    private val layerPolicies = mutableListOf<ArchitectureLayerPolicy>()
+
     /** Returns a [ClassSelector] for all classes in the project graph. */
     public val classes: ClassSelector get() = KontureScope.fromProject(projectGraph)
 
@@ -127,6 +129,21 @@ public class KontureContext(
     }
 
     /**
+     * Declares a first-class architectural layer with module/package selectors and
+     * explicit dependency boundaries inside this architecture validation context.
+     *
+     * @param name The unique, human-readable name of the layer.
+     * @param block Declarative layer policy scoped to [ArchitectureLayerPolicy].
+     */
+    public fun layer(
+        name: String,
+        block: ArchitectureLayerPolicy.() -> Unit,
+    ) {
+        val policy = ArchitectureLayerPolicy(name).apply(block)
+        layerPolicies.add(policy)
+    }
+
+    /**
      * Declares a nested, type-safe layered-architecture specification inside this architecture validation context.
      */
     public fun layered(block: LayeredArchitectureDsl.() -> Unit) {
@@ -157,6 +174,9 @@ public class KontureContext(
 
     internal fun verifyAll() {
         /** Filter or assertion criteria for failures. */
+        if (layerPolicies.isNotEmpty()) {
+            addSuite("layers") { checkLayerPolicies(layerPolicies, projectGraph) }
+        }
         val failures = mutableListOf<String>()
         for (suite in ruleSuites) {
             try {

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages.properties
@@ -492,3 +492,12 @@ suppression.logged.debug=Suppressed violation for rule ''{0}'' on {1}: {2}
 # Diagnostics & Severity Thresholds
 diagnostic.subThresholdViolation=[Konture] {0} violation (non-blocking) in rule ''{1}'': {2}
 
+
+# First-class architecture layer policy DSL
+architecture.policy.violationHeader=Architecture policy violation(s) detected:
+architecture.policy.mayDependOn=Layer {0} may only depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
+architecture.policy.mustNotDependOn=Layer {0} must not depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
+architecture.policy.mayBeAccessedBy=Layer {0} may only be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
+architecture.policy.mustNotBeAccessedBy=Layer {0} must not be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
+architecture.policy.noSelector=Architecture layer {0} declares no selector; specify a selector with modules or packages.
+architecture.policy.undefinedLayer=Architecture layer policy references undefined layer(s): {0}. Declare them with layer() before referencing.

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_es.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_es.properties
@@ -565,3 +565,12 @@ suppression.logged.debug=Violaci\u00f3n suprimida para la regla ''{0}'' en {1}: 
 # Diagnostics & Severity Thresholds
 diagnostic.subThresholdViolation=[Konture] Violaci\u00f3n {0} (no bloqueante) en la regla ''{1}'': {2}
 
+
+# First-class architecture layer policy DSL
+architecture.policy.violationHeader=Se han detectado una o varias infracciones de la política de arquitectura:
+architecture.policy.mayDependOn=La capa {0} solo puede depender de las capas [{1}], pero la clase {2} depende de {3} en la(s) capa(s) [{4}] (en {5})
+architecture.policy.mustNotDependOn=La capa {0} no debe depender de las capas [{1}], pero la clase {2} depende de {3} en la(s) capa(s) [{4}] (en {5})
+architecture.policy.mayBeAccessedBy=Solo las capas [{1}] pueden acceder a la capa {0}, pero la clase {2} de las capas [{3}] depende de {4} (en {5})
+architecture.policy.mustNotBeAccessedBy=Las capas [{1}] no deben acceder a la capa {0}, pero la clase {2} de las capas [{3}] depende de {4} (en {5})
+architecture.policy.noSelector=La capa de arquitectura {0} no declara ningún selector; especifica un selector con módulos o paquetes.
+architecture.policy.undefinedLayer=La política de la capa de arquitectura hace referencia a una o varias capas no definidas: {0}. Decláralas con layer() antes de hacer referencia a ellas.

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_fr.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_fr.properties
@@ -568,10 +568,10 @@ diagnostic.subThresholdViolation=[Konture] Violation {0} (non bloquante) dans la
 
 
 # First-class architecture layer policy DSL
-architecture.policy.violationHeader=Architecture policy violation(s) detected:
-architecture.policy.mayDependOn=Layer {0} may only depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
-architecture.policy.mustNotDependOn=Layer {0} must not depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
-architecture.policy.mayBeAccessedBy=Layer {0} may only be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
-architecture.policy.mustNotBeAccessedBy=Layer {0} must not be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
-architecture.policy.noSelector=Architecture layer {0} declares no selector; specify a selector with modules or packages.
-architecture.policy.undefinedLayer=Architecture layer policy references undefined layer(s): {0}. Declare them with layer() before referencing.
+architecture.policy.violationHeader=Violation(s) de la politique d''architecture détectée(s) :
+architecture.policy.mayDependOn=La couche {0} ne peut dépendre que des couches [{1}], mais la classe {2} dépend de {3} dans la/les couche(s) [{4}] (à {5})
+architecture.policy.mustNotDependOn=La couche {0} ne doit pas dépendre des couches [{1}], mais la classe {2} dépend de {3} dans la/les couche(s) [{4}] (à {5})
+architecture.policy.mayBeAccessedBy=La couche {0} ne peut être accessible que par les couches [{1}], mais la classe {2} des couches [{3}] dépend de {4} (à {5})
+architecture.policy.mustNotBeAccessedBy=La couche {0} ne doit pas être accessible par les couches [{1}], mais la classe {2} des couches [{3}] dépend de {4} (à {5})
+architecture.policy.noSelector=La couche d''architecture {0} ne déclare aucun sélecteur ; précisez un sélecteur avec modules ou packages.
+architecture.policy.undefinedLayer=La politique de couche d''architecture référence des couches non définies : {0}. Déclarez-les avec layer() avant de les référencer.

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_fr.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_fr.properties
@@ -566,3 +566,12 @@ suppression.logged.debug=Violation supprim\u00e9e pour la r\u00e8gle ''{0}'' sur
 # Diagnostics & Severity Thresholds
 diagnostic.subThresholdViolation=[Konture] Violation {0} (non bloquante) dans la r\u00e8gle ''{1}'' : {2}
 
+
+# First-class architecture layer policy DSL
+architecture.policy.violationHeader=Architecture policy violation(s) detected:
+architecture.policy.mayDependOn=Layer {0} may only depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
+architecture.policy.mustNotDependOn=Layer {0} must not depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
+architecture.policy.mayBeAccessedBy=Layer {0} may only be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
+architecture.policy.mustNotBeAccessedBy=Layer {0} must not be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
+architecture.policy.noSelector=Architecture layer {0} declares no selector; specify a selector with modules or packages.
+architecture.policy.undefinedLayer=Architecture layer policy references undefined layer(s): {0}. Declare them with layer() before referencing.

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_it.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_it.properties
@@ -568,10 +568,10 @@ diagnostic.subThresholdViolation=[Konture] Violazione {0} (non bloccante) nella 
 
 
 # First-class architecture layer policy DSL
-architecture.policy.violationHeader=Architecture policy violation(s) detected:
-architecture.policy.mayDependOn=Layer {0} may only depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
-architecture.policy.mustNotDependOn=Layer {0} must not depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
-architecture.policy.mayBeAccessedBy=Layer {0} may only be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
-architecture.policy.mustNotBeAccessedBy=Layer {0} must not be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
-architecture.policy.noSelector=Architecture layer {0} declares no selector; specify a selector with modules or packages.
-architecture.policy.undefinedLayer=Architecture layer policy references undefined layer(s): {0}. Declare them with layer() before referencing.
+architecture.policy.violationHeader=Rilevata/e violazione/i della politica di architettura:
+architecture.policy.mayDependOn=Lo strato {0} può dipendere solo dagli strati [{1}], ma la classe {2} dipende da {3} nello/gli strato/i [{4}] (a {5})
+architecture.policy.mustNotDependOn=Lo strato {0} non deve dipendere dagli strati [{1}], ma la classe {2} dipende da {3} nello/gli strato/i [{4}] (a {5})
+architecture.policy.mayBeAccessedBy=Lo strato {0} può essere accessibile solo dagli strati [{1}], ma la classe {2} nello/gli strato/i [{3}] dipende da {4} (a {5})
+architecture.policy.mustNotBeAccessedBy=Lo strato {0} non deve essere accessibile dagli strati [{1}], ma la classe {2} nello/gli strato/i [{3}] dipende da {4} (a {5})
+architecture.policy.noSelector=Lo strato di architettura {0} non dichiara alcun selettore; specifica un selettore con modules o packages.
+architecture.policy.undefinedLayer=La politica dello strato di architettura fa riferimento a strato/i non definito/i: {0}. Dichiarali con layer() prima di utilizzarli.

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_it.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_it.properties
@@ -566,3 +566,12 @@ suppression.logged.debug=Violazione soppressa per la regola ''{0}'' su {1}: {2}
 # Diagnostics & Severity Thresholds
 diagnostic.subThresholdViolation=[Konture] Violazione {0} (non bloccante) nella regola ''{1}'': {2}
 
+
+# First-class architecture layer policy DSL
+architecture.policy.violationHeader=Architecture policy violation(s) detected:
+architecture.policy.mayDependOn=Layer {0} may only depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
+architecture.policy.mustNotDependOn=Layer {0} must not depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
+architecture.policy.mayBeAccessedBy=Layer {0} may only be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
+architecture.policy.mustNotBeAccessedBy=Layer {0} must not be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
+architecture.policy.noSelector=Architecture layer {0} declares no selector; specify a selector with modules or packages.
+architecture.policy.undefinedLayer=Architecture layer policy references undefined layer(s): {0}. Declare them with layer() before referencing.

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_vi.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_vi.properties
@@ -566,3 +566,12 @@ suppression.logged.debug=\u0110\u00e3 b\u1ecf qua vi ph\u1ea1m cho quy t\u1eafc 
 # Diagnostics & Severity Thresholds
 diagnostic.subThresholdViolation=[Konture] Vi ph\u1ea1m {0} (kh\u00f4ng ch\u1eb7n) trong quy t\u1eafc ''{1}'': {2}
 
+
+# First-class architecture layer policy DSL
+architecture.policy.violationHeader=Architecture policy violation(s) detected:
+architecture.policy.mayDependOn=Layer {0} may only depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
+architecture.policy.mustNotDependOn=Layer {0} must not depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
+architecture.policy.mayBeAccessedBy=Layer {0} may only be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
+architecture.policy.mustNotBeAccessedBy=Layer {0} must not be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
+architecture.policy.noSelector=Architecture layer {0} declares no selector; specify a selector with modules or packages.
+architecture.policy.undefinedLayer=Architecture layer policy references undefined layer(s): {0}. Declare them with layer() before referencing.

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_vi.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_vi.properties
@@ -568,10 +568,10 @@ diagnostic.subThresholdViolation=[Konture] Vi ph\u1ea1m {0} (kh\u00f4ng ch\u1eb7
 
 
 # First-class architecture layer policy DSL
-architecture.policy.violationHeader=Architecture policy violation(s) detected:
-architecture.policy.mayDependOn=Layer {0} may only depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
-architecture.policy.mustNotDependOn=Layer {0} must not depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
-architecture.policy.mayBeAccessedBy=Layer {0} may only be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
-architecture.policy.mustNotBeAccessedBy=Layer {0} must not be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
-architecture.policy.noSelector=Architecture layer {0} declares no selector; specify a selector with modules or packages.
-architecture.policy.undefinedLayer=Architecture layer policy references undefined layer(s): {0}. Declare them with layer() before referencing.
+architecture.policy.violationHeader=Phát hiện vi phạm chính sách kiến trúc:
+architecture.policy.mayDependOn=Tầng {0} chỉ có thể phụ thuộc các tầng [{1}], nhưng lớp {2} lại phụ thuộc vào {3} trong (các) tầng [{4}] (tại {5})
+architecture.policy.mustNotDependOn=Tầng {0} không được phép phụ thuộc các tầng [{1}], nhưng lớp {2} lại phụ thuộc vào {3} trong (các) tầng [{4}] (tại {5})
+architecture.policy.mayBeAccessedBy=Tầng {0} chỉ có thể được truy cập bởi các tầng [{1}], nhưng lớp {2} trong (các) tầng [{3}] lại phụ thuộc vào {4} (tại {5})
+architecture.policy.mustNotBeAccessedBy=Tầng {0} không được phép được truy cập bởi các tầng [{1}], nhưng lớp {2} trong (các) tầng [{3}] lại phụ thuộc vào {4} (tại {5})
+architecture.policy.noSelector=Tầng kiến trúc {0} không khai báo bộ chọn; hãy chỉ định bộ chọn với modules hoặc packages.
+architecture.policy.undefinedLayer=Chính sách tầng kiến trúc tham chiếu (các) tầng chưa được khai báo: {0}. Hãy khai báo chúng bằng layer() trước khi tham chiếu.

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_zh.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_zh.properties
@@ -568,10 +568,10 @@ suppression.logged.debug=\u5df2\u6291\u5236\u89c4\u5219 ''{0}'' \u5728 {1} \u4e0
 diagnostic.subThresholdViolation=[Konture] \u89c4\u5219 ''{1}'' \u4e2d\u7684 {0} \u8fdd\u89c4\uff08\u975e\u963b\u585e\uff09: {2}
 
 # First-class architecture layer policy DSL
-architecture.policy.violationHeader=Architecture policy violation(s) detected:
-architecture.policy.mayDependOn=Layer {0} may only depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
-architecture.policy.mustNotDependOn=Layer {0} must not depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
-architecture.policy.mayBeAccessedBy=Layer {0} may only be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
-architecture.policy.mustNotBeAccessedBy=Layer {0} must not be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
-architecture.policy.noSelector=Architecture layer {0} declares no selector; specify a selector with modules or packages.
-architecture.policy.undefinedLayer=Architecture layer policy references undefined layer(s): {0}. Declare them with layer() before referencing.
+architecture.policy.violationHeader=检测到架构策略违规：
+architecture.policy.mayDependOn=层 {0} 只能依赖层 [{1}]，但类 {2} 依赖了层 [{4}] 中的 {3}（位于 {5}）
+architecture.policy.mustNotDependOn=层 {0} 不能依赖层 [{1}]，但类 {2} 依赖了层 [{4}] 中的 {3}（位于 {5}）
+architecture.policy.mayBeAccessedBy=层 {0} 只能由层 [{1}] 访问，但层 [{3}] 中的类 {2} 依赖了 {4}（位于 {5}）
+architecture.policy.mustNotBeAccessedBy=层 {0} 不能由层 [{1}] 访问，但层 [{3}] 中的类 {2} 依赖了 {4}（位于 {5}）
+architecture.policy.noSelector=架构层 {0} 未声明选择器；请使用 modules 或 packages 指定一个选择器。
+architecture.policy.undefinedLayer=架构层策略引用了未定义的层：{0}。请先用 layer() 声明它们，再行引用。

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_zh.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_zh.properties
@@ -566,3 +566,12 @@ suppression.logged.debug=\u5df2\u6291\u5236\u89c4\u5219 ''{0}'' \u5728 {1} \u4e0
 
 # Diagnostics & Severity Thresholds
 diagnostic.subThresholdViolation=[Konture] \u89c4\u5219 ''{1}'' \u4e2d\u7684 {0} \u8fdd\u89c4\uff08\u975e\u963b\u585e\uff09: {2}
+
+# First-class architecture layer policy DSL
+architecture.policy.violationHeader=Architecture policy violation(s) detected:
+architecture.policy.mayDependOn=Layer {0} may only depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
+architecture.policy.mustNotDependOn=Layer {0} must not depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
+architecture.policy.mayBeAccessedBy=Layer {0} may only be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
+architecture.policy.mustNotBeAccessedBy=Layer {0} must not be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
+architecture.policy.noSelector=Architecture layer {0} declares no selector; specify a selector with modules or packages.
+architecture.policy.undefinedLayer=Architecture layer policy references undefined layer(s): {0}. Declare them with layer() before referencing.

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_CN.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_CN.properties
@@ -565,3 +565,12 @@ suppression.logged.debug=\u5df2\u6291\u5236\u89c4\u5219 ''{0}'' \u5728 {1} \u4e0
 
 # Diagnostics & Severity Thresholds
 diagnostic.subThresholdViolation=[Konture] \u89c4\u5219 ''{1}'' \u4e2d\u7684 {0} \u8fdd\u89c4\uff08\u975e\u963b\u585e\uff09: {2}
+
+# First-class architecture layer policy DSL
+architecture.policy.violationHeader=Architecture policy violation(s) detected:
+architecture.policy.mayDependOn=Layer {0} may only depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
+architecture.policy.mustNotDependOn=Layer {0} must not depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
+architecture.policy.mayBeAccessedBy=Layer {0} may only be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
+architecture.policy.mustNotBeAccessedBy=Layer {0} must not be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
+architecture.policy.noSelector=Architecture layer {0} declares no selector; specify a selector with modules or packages.
+architecture.policy.undefinedLayer=Architecture layer policy references undefined layer(s): {0}. Declare them with layer() before referencing.

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_CN.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_CN.properties
@@ -567,10 +567,10 @@ suppression.logged.debug=\u5df2\u6291\u5236\u89c4\u5219 ''{0}'' \u5728 {1} \u4e0
 diagnostic.subThresholdViolation=[Konture] \u89c4\u5219 ''{1}'' \u4e2d\u7684 {0} \u8fdd\u89c4\uff08\u975e\u963b\u585e\uff09: {2}
 
 # First-class architecture layer policy DSL
-architecture.policy.violationHeader=Architecture policy violation(s) detected:
-architecture.policy.mayDependOn=Layer {0} may only depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
-architecture.policy.mustNotDependOn=Layer {0} must not depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
-architecture.policy.mayBeAccessedBy=Layer {0} may only be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
-architecture.policy.mustNotBeAccessedBy=Layer {0} must not be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
-architecture.policy.noSelector=Architecture layer {0} declares no selector; specify a selector with modules or packages.
-architecture.policy.undefinedLayer=Architecture layer policy references undefined layer(s): {0}. Declare them with layer() before referencing.
+architecture.policy.violationHeader=检测到架构策略违规：
+architecture.policy.mayDependOn=层 {0} 只能依赖层 [{1}]，但类 {2} 依赖了层 [{4}] 中的 {3}（位于 {5}）
+architecture.policy.mustNotDependOn=层 {0} 不能依赖层 [{1}]，但类 {2} 依赖了层 [{4}] 中的 {3}（位于 {5}）
+architecture.policy.mayBeAccessedBy=层 {0} 只能由层 [{1}] 访问，但层 [{3}] 中的类 {2} 依赖了 {4}（位于 {5}）
+architecture.policy.mustNotBeAccessedBy=层 {0} 不能由层 [{1}] 访问，但层 [{3}] 中的类 {2} 依赖了 {4}（位于 {5}）
+architecture.policy.noSelector=架构层 {0} 未声明选择器；请使用 modules 或 packages 指定一个选择器。
+architecture.policy.undefinedLayer=架构层策略引用了未定义的层：{0}。请先用 layer() 声明它们，再行引用。

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_TW.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_TW.properties
@@ -565,3 +565,12 @@ suppression.logged.debug=\u5df2\u6291\u5236\u898f\u5247 ''{0}'' \u65bc {1} \u4e0
 # Diagnostics & Severity Thresholds
 diagnostic.subThresholdViolation=[Konture] \u898f\u5247 ''{1}'' \u4e2d\u7684 {0} \u9055\u898f\uff08\u975e\u963b\u585e\uff09: {2}
 
+
+# First-class architecture layer policy DSL
+architecture.policy.violationHeader=Architecture policy violation(s) detected:
+architecture.policy.mayDependOn=Layer {0} may only depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
+architecture.policy.mustNotDependOn=Layer {0} must not depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
+architecture.policy.mayBeAccessedBy=Layer {0} may only be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
+architecture.policy.mustNotBeAccessedBy=Layer {0} must not be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
+architecture.policy.noSelector=Architecture layer {0} declares no selector; specify a selector with modules or packages.
+architecture.policy.undefinedLayer=Architecture layer policy references undefined layer(s): {0}. Declare them with layer() before referencing.

--- a/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_TW.properties
+++ b/library/src/main/resources/io/github/baole/konture/i18n/messages_zh_TW.properties
@@ -567,10 +567,10 @@ diagnostic.subThresholdViolation=[Konture] \u898f\u5247 ''{1}'' \u4e2d\u7684 {0}
 
 
 # First-class architecture layer policy DSL
-architecture.policy.violationHeader=Architecture policy violation(s) detected:
-architecture.policy.mayDependOn=Layer {0} may only depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
-architecture.policy.mustNotDependOn=Layer {0} must not depend on layers [{1}], but class {2} depends on {3} in layer(s) [{4}] (at {5})
-architecture.policy.mayBeAccessedBy=Layer {0} may only be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
-architecture.policy.mustNotBeAccessedBy=Layer {0} must not be accessed by layers [{1}], but class {2} in layer(s) [{3}] depends on {4} (at {5})
-architecture.policy.noSelector=Architecture layer {0} declares no selector; specify a selector with modules or packages.
-architecture.policy.undefinedLayer=Architecture layer policy references undefined layer(s): {0}. Declare them with layer() before referencing.
+architecture.policy.violationHeader=偵測到架構策略違規：
+architecture.policy.mayDependOn=層 {0} 只能依賴層 [{1}]，但類別 {2} 依賴了層 [{4}] 中的 {3}（位於 {5}）
+architecture.policy.mustNotDependOn=層 {0} 不能依賴層 [{1}]，但類別 {2} 依賴了層 [{4}] 中的 {3}（位於 {5}）
+architecture.policy.mayBeAccessedBy=層 {0} 只能由層 [{1}] 存取，但層 [{3}] 中的類別 {2} 依賴了 {4}（位於 {5}）
+architecture.policy.mustNotBeAccessedBy=層 {0} 不能由層 [{1}] 存取，但層 [{3}] 中的類別 {2} 依賴了 {4}（位於 {5}）
+architecture.policy.noSelector=架構層 {0} 未宣告選取器；請使用 modules 或 packages 指定一個選取器。
+architecture.policy.undefinedLayer=架構層策略參照了未定義的層：{0}。請先用 layer() 宣告它們，再行參照。

--- a/library/src/test/kotlin/io/github/baole/konture/ArchitectureLayerPolicyTest.kt
+++ b/library/src/test/kotlin/io/github/baole/konture/ArchitectureLayerPolicyTest.kt
@@ -1,0 +1,337 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Octavio Calleya Garcia (@octaviospain)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the first-class architectural layer policy DSL declared directly
+ * inside an `architecture { ... }` block (see issue #69).
+ */
+class ArchitectureLayerPolicyTest : RuleBuildersTestBase() {
+    /** Returns [source] configured to depend on the class identified by [targetFqName]. */
+    private fun dependingOn(
+        source: ClassDeclaration,
+        targetFqName: String,
+        targetSimpleName: String,
+    ): ClassDeclaration =
+        source.copy(
+            imports = listOf(targetFqName),
+            referencedTypes = setOf(targetSimpleName),
+        )
+
+    private fun graphWith(modules: List<Module>): ProjectGraph {
+        return ProjectGraph(builds = mapOf(":" to modules)).also { ProjectGraph.setDefault(it) }
+    }
+
+    @Test
+    fun `mayDependOn permits dependency to an allowed layer`() {
+        val graph =
+            graphWith(
+                listOf(
+                    moduleA.copy(
+                        files =
+                            listOf(
+                                FileDeclaration(
+                                    "ClassA.kt",
+                                    "com.example",
+                                    classes = listOf(dependingOn(classA, "com.other.ClassC", "ClassC")),
+                                ),
+                            ),
+                    ),
+                    moduleB,
+                    moduleC,
+                ),
+            )
+        assertDoesNotThrow {
+            architecture {
+                layer("presentation") {
+                    selector { packages("com.example") }
+                    mayDependOn("domain")
+                }
+                layer("domain") {
+                    selector { packages("com.other") }
+                }
+            }
+        }
+        assertTrue(graph.getAllModules().isNotEmpty())
+    }
+
+    @Test
+    fun `mayDependOn rejects dependency to a layer that is not allowed`() {
+        graphWith(
+            listOf(
+                moduleA.copy(
+                    files =
+                        listOf(
+                            FileDeclaration(
+                                "ClassA.kt",
+                                "com.example",
+                                classes = listOf(dependingOn(classA, "com.other.ClassC", "ClassC")),
+                            ),
+                        ),
+                ),
+                moduleB,
+                moduleC,
+            ),
+        )
+        val exception =
+            assertThrows(AssertionError::class.java) {
+                architecture {
+                    layer("presentation") {
+                        selector { packages("com.example") }
+                        mayDependOn("core")
+                    }
+                    layer("domain") {
+                        selector { packages("com.other") }
+                    }
+                    layer("core") {
+                        selector { packages("com.core") }
+                    }
+                }
+            }
+        assertTrue(exception.message!!.contains("may only depend on layers [core]"))
+        assertTrue(exception.message!!.contains("depends on com.other.ClassC"))
+    }
+
+    @Test
+    fun `mayDependOn allows intra-layer and uncategorized dependencies`() {
+        // ClassA depends on ClassB (same presentation layer) and ClassC (uncategorized module).
+        val dependingClassA =
+            dependingOn(classA, "com.example.ClassB", "ClassB")
+                .copy(
+                    imports = listOf("com.example.ClassB", "com.other.ClassC"),
+                    referencedTypes = setOf("ClassB", "ClassC"),
+                )
+        val fileA = FileDeclaration("ClassA.kt", "com.example", classes = listOf(dependingClassA))
+        graphWith(
+            listOf(
+                moduleA.copy(files = listOf(fileA)),
+                moduleB,
+                moduleC,
+            ),
+        )
+        // domain is declared but empty (no classes match); ClassC is uncategorized.
+        assertDoesNotThrow {
+            architecture {
+                layer("presentation") {
+                    selector { packages("com.example") }
+                    mayDependOn("domain")
+                }
+                layer("domain") {
+                    selector { packages("com.acme.unused") }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `referencing an undefined layer is rejected`() {
+        graphWith(listOf(moduleA, moduleB, moduleC))
+        val exception =
+            assertThrows(IllegalArgumentException::class.java) {
+                architecture {
+                    layer("presentation") {
+                        selector { packages("com.example") }
+                        mayDependOn("typoLayer")
+                    }
+                }
+            }
+        assertTrue(exception.message!!.contains("undefined layer"))
+        assertTrue(exception.message!!.contains("typoLayer"))
+    }
+
+    @Test
+    fun `mustNotDependOn rejects dependency to a forbidden layer`() {
+        graphWith(
+            listOf(
+                moduleA.copy(
+                    files =
+                        listOf(
+                            FileDeclaration(
+                                "ClassA.kt",
+                                "com.example",
+                                classes = listOf(dependingOn(classA, "com.other.ClassC", "ClassC")),
+                            ),
+                        ),
+                ),
+                moduleB,
+                moduleC,
+            ),
+        )
+        val exception =
+            assertThrows(AssertionError::class.java) {
+                architecture {
+                    layer("application") {
+                        selector { modules(":moduleA") }
+                        mustNotDependOn("data")
+                    }
+                    layer("data") {
+                        selector { modules(":moduleC") }
+                    }
+                }
+            }
+        assertTrue(exception.message!!.contains("must not depend on layers [data]"))
+        assertTrue(exception.message!!.contains("com.other.ClassC"))
+    }
+
+    @Test
+    fun `module selector drives layer boundary enforcement`() {
+        graphWith(
+            listOf(
+                moduleA.copy(
+                    files =
+                        listOf(
+                            FileDeclaration(
+                                "ClassA.kt",
+                                "com.example",
+                                classes = listOf(dependingOn(classA, "com.other.ClassC", "ClassC")),
+                            ),
+                        ),
+                ),
+                moduleB,
+                moduleC,
+            ),
+        )
+        // app(:moduleA) mayDependOn data(:moduleC); the ClassA -> ClassC edge is allowed.
+        assertDoesNotThrow {
+            architecture {
+                layer("app") {
+                    selector { modules(":moduleA") }
+                    mayDependOn("data")
+                }
+                layer("data") {
+                    selector { modules(":moduleC") }
+                }
+            }
+        }
+        // Same setup with mustNotDependOn data yields a violation.
+        val exception =
+            assertThrows(AssertionError::class.java) {
+                architecture {
+                    layer("app") {
+                        selector { modules(":moduleA") }
+                        mustNotDependOn("data")
+                    }
+                    layer("data") {
+                        selector { modules(":moduleC") }
+                    }
+                }
+            }
+        assertTrue(exception.message!!.contains("must not depend on layers [data]"))
+    }
+
+    @Test
+    fun `mayBeAccessedBy permits and rejects callers`() {
+        // ClassA (com.example) depends on ClassC (com.other).
+        val appClassA = dependingOn(classA, "com.other.ClassC", "ClassC")
+        graphWith(
+            listOf(
+                moduleA.copy(files = listOf(FileDeclaration("ClassA.kt", "com.example", classes = listOf(appClassA)))),
+                moduleB,
+                moduleC,
+            ),
+        )
+
+        assertDoesNotThrow {
+            architecture {
+                layer("presentation") {
+                    selector { packages("com.example") }
+                }
+                layer("domain") {
+                    selector { packages("com.other") }
+                    mayBeAccessedBy("presentation")
+                }
+            }
+        }
+
+        val exception =
+            assertThrows(AssertionError::class.java) {
+                architecture {
+                    layer("presentation") {
+                        selector { packages("com.example") }
+                    }
+                    layer("domain") {
+                        selector { packages("com.other") }
+                        mayBeAccessedBy("data")
+                    }
+                    layer("data") {
+                        selector { packages("com.data") }
+                    }
+                }
+            }
+        assertTrue(exception.message!!.contains("may only be accessed by layers [data]"))
+        assertTrue(exception.message!!.contains("depends on com.other.ClassC"))
+    }
+
+    @Test
+    fun `mustNotBeAccessedBy rejects a forbidden caller`() {
+        graphWith(
+            listOf(
+                moduleA.copy(
+                    files =
+                        listOf(
+                            FileDeclaration(
+                                "ClassA.kt",
+                                "com.example",
+                                classes = listOf(dependingOn(classA, "com.other.ClassC", "ClassC")),
+                            ),
+                        ),
+                ),
+                moduleB,
+                moduleC,
+            ),
+        )
+        val exception =
+            assertThrows(AssertionError::class.java) {
+                architecture {
+                    layer("presentation") {
+                        selector { packages("com.example") }
+                    }
+                    layer("domain") {
+                        selector { packages("com.other") }
+                        mustNotBeAccessedBy("presentation")
+                    }
+                }
+            }
+        assertTrue(exception.message!!.contains("must not be accessed by layers [presentation]"))
+        assertTrue(exception.message!!.contains("depends on com.other.ClassC"))
+    }
+
+    @Test
+    fun `layer without a selector fails with IllegalArgumentException`() {
+        graphWith(listOf(moduleA, moduleB, moduleC))
+        val exception =
+            assertThrows(IllegalArgumentException::class.java) {
+                architecture {
+                    layer("orphan") {
+                        mayDependOn("domain")
+                    }
+                }
+            }
+        assertTrue(exception.message!!.contains("declares no selector"))
+    }
+
+    @Test
+    fun `layer DSL works inside Konture architecture block with mixed suites`() {
+        graphWith(listOf(moduleA, moduleB, moduleC))
+        assertDoesNotThrow {
+            Konture.architecture {
+                layer("domain") {
+                    selector { packages("com.other") }
+                    mayDependOn("core")
+                }
+                layer("core") {
+                    selector { packages("com.core") }
+                }
+            }
+        }
+    }
+}

--- a/library/src/test/kotlin/io/github/baole/konture/impl/I18nTest.kt
+++ b/library/src/test/kotlin/io/github/baole/konture/impl/I18nTest.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -203,6 +203,82 @@ class I18nTest {
                 emptyByFile.entries.joinToString("\n") { (file, keys) ->
                     "  $file (${keys.size} empty): ${keys.take(10)}${if (keys.size > 10) "..." else ""}"
                 },
+        )
+    }
+
+    @Test
+    fun testArchitectureLayerPolicyTranslationsInAllLocales() {
+        val spyLayer = "feature"
+        val allowed = "core, domain"
+        val sourceClass = "com.example.Presenter"
+        val targetClass = "com.domain.Widget"
+        val targetLayer = "domain"
+        val at = "Presenter.kt:10"
+
+        // Arg lists per key must match getMessage(...) call signatures in ArchitectureLayerPolicy.
+        val argsByKey: Map<String, Array<Any?>> =
+            mapOf(
+                "architecture.policy.violationHeader" to arrayOf(),
+                "architecture.policy.mayDependOn" to arrayOf(spyLayer, allowed, sourceClass, targetClass, targetLayer, at),
+                "architecture.policy.mustNotDependOn" to arrayOf(spyLayer, allowed, sourceClass, targetClass, targetLayer, at),
+                "architecture.policy.mayBeAccessedBy" to arrayOf(spyLayer, allowed, sourceClass, targetLayer, targetClass, at),
+                "architecture.policy.mustNotBeAccessedBy" to arrayOf(spyLayer, allowed, sourceClass, targetLayer, targetClass, at),
+                "architecture.policy.noSelector" to arrayOf(spyLayer),
+                "architecture.policy.undefinedLayer" to arrayOf("typoLayer"),
+            )
+
+        for (locale in SUPPORTED_LOCALES) {
+            Konture.locale = locale
+            for ((key, args) in argsByKey) {
+                val rendered = getMessage(key, *args)
+                assertFalse(
+                    rendered.startsWith("[$key"),
+                    "$key resolved to fallback placeholder in ${locale.language}: '$rendered'",
+                )
+                if (args.isNotEmpty()) {
+                    assertTrue(
+                        rendered.contains(args.first().toString()),
+                        "$key lost its arguments in ${locale.language}: '$rendered'",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testArchitectureLayerPolicyTranslationsWording() {
+        val args =
+            arrayOf(
+                "feature",
+                "core, domain",
+                "com.example.Presenter",
+                "com.domain.Widget",
+                "domain",
+                "Presenter.kt:10",
+            )
+
+        // Spanish
+        Konture.locale = Locale.forLanguageTag("es")
+        assertEquals(
+            "La capa feature solo puede depender de las capas [core, domain], pero la clase " +
+                "com.example.Presenter depende de com.domain.Widget en la(s) capa(s) [domain] (en Presenter.kt:10)",
+            getMessage("architecture.policy.mayDependOn", *args),
+        )
+
+        // French
+        Konture.locale = Locale.FRENCH
+        assertEquals(
+            "La couche feature ne peut dépendre que des couches [core, domain], mais la classe " +
+                "com.example.Presenter dépend de com.domain.Widget dans la/les couche(s) [domain] (à Presenter.kt:10)",
+            getMessage("architecture.policy.mayDependOn", *args),
+        )
+
+        // Italian
+        Konture.locale = Locale.ITALIAN
+        assertEquals(
+            "Lo strato feature può dipendere solo dagli strati [core, domain], ma la classe " +
+                "com.example.Presenter dipende da com.domain.Widget nello/gli strato/i [domain] (a Presenter.kt:10)",
+            getMessage("architecture.policy.mayDependOn", *args),
         )
     }
 


### PR DESCRIPTION
## Summary

**Issue: #69 — First-Class Architectural Layers & `architecturePolicy` DSL**
**Target:** Konture 0.11.0
**Status:** Verified ✓ (`:library:check` green)

Adds a first-class, declarative `layer(...)` policy DSL usable directly inside the existing `architecture { }` block (the `KontureContext` receiver), elevating Konture from low-level module/package assertions to high-level layer-boundary definitions.

```kotlin
architecture {
    layer("feature") {
        selector { modules(":feature:**") }
        mayDependOn("core", "domain")
        mustNotDependOn("feature")
    }
    layer("domain") {
        selector { modules(":domain:**") }
        mayDependOn("core")
    }
}
```

## Changes

New `ArchitectureLayerPolicy.kt` introduces:
- **`layer("name") { ... }`** — declares a layer with module-glob (`selector { modules(":feature:**") }`) and/or package (`selector { packages("com.acme.domain..") }`) selectors.
- **Boundary verbs** — `mayDependOn(...)`, `mustNotDependOn(...)`, `mayBeAccessedBy(...)`, `mustNotBeAccessedBy(...)`. Intra-layer and uncategorized dependencies are permitted unless explicitly forbidden.
- **Compiles to primitives** — layer membership lowers to the primitive module-glob/package matchers and the class-level `dependsOn` assertion, running through the existing severity/baseline report machinery.
- **Typos can't silently pass** — referencing an undeclared layer name is rejected up front.
- i18n message keys added across all locale bundles; public ABI dump regenerated.

**Key files**
- `library/src/main/kotlin/io/github/baole/konture/ArchitectureLayerPolicy.kt` (new)
- `library/src/main/kotlin/io/github/baole/konture/KontureContext.kt` (modified: `layer()` + `verifyAll()` wiring)
- `library/src/test/kotlin/io/github/baole/konture/ArchitectureLayerPolicyTest.kt` (new)
- `library/api/library.api`, 8x i18n `messages_*.properties`

## Acceptance Criteria

- [x] `architecture { ... }` top-level builder implemented in `library`.
- [x] `layer("name") { ... }` builder supporting module and package selectors.
- [x] Layer definition compiles down to primitive Konture selectors and assertions.
- [x] Comprehensive unit tests verifying layer boundary enforcement.

## Verification

- [x] Automated: `./gradlew -q :library:test` — full suite passes, **10 new tests** in `ArchitectureLayerPolicyTest` (mayDependOn / mustNotDependOn / mayBeAccessedBy / mustNotBeAccessedBy, module and package selectors, undefined-layer guard, no-selector error).
- [x] Automated: `./gradlew :library:check` — tests, Detekt, Ktlint (main + test), Spotless, Jacoco coverage, ABI check all green.
- [x] Code review (Standards + Spec axes) performed during implementation; findings addressed (undefined-layer guard, i18n routing for preconditions).

## Key Decisions

- **`architecture {}` over a separate `architecturePolicy` entry point** — matches the issue's own body/AC syntax; `layer()` is a `KontureContext` member, so it slots into the existing unified validation block and its `verifyAll()` aggregation.
- **`mayBeAccessedBy` / `mustNotBeAccessedBy`** added as the symmetric inbound boundary primitives alongside the two outbound verbs in the spec sample.
- **Intra-layer and uncategorized dependencies are permitted** by `may*` unless a `mustNot*` forbids them; a layer's `mustNotDependOn("self")` (as in the spec sample) *does* still fire.
- **Known follow-up:** the 7 non-English locale bundles carry the new keys as English copies — real translations by native speakers are still needed for full localization (fallback is English, not a placeholder).
