### PR TITLE
feat(library): reusable rule sets & packageable policies

### DIFF
--- a/library/api/library.api
+++ b/library/api/library.api
@@ -3421,6 +3421,7 @@ public final class io/github/baole/konture/Konture {
 
 public final class io/github/baole/konture/KontureContext {
 	public fun <init> (Lio/github/baole/konture/ProjectGraph;)V
+	public final fun apply (Lio/github/baole/konture/RuleSet;)V
 	public final fun classes (Lkotlin/jvm/functions/Function1;)V
 	public final fun files (Lkotlin/jvm/functions/Function1;)V
 	public final fun functions (Lkotlin/jvm/functions/Function1;)V
@@ -5397,6 +5398,30 @@ public final class io/github/baole/konture/RuleDefinition {
 
 public final class io/github/baole/konture/RuleDslKt {
 	public static final fun rule (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/github/baole/konture/RuleDefinition;
+}
+
+public final class io/github/baole/konture/RuleSet {
+}
+
+public final class io/github/baole/konture/RuleSetBuilder {
+	public fun <init> ()V
+	public final fun classes (Lkotlin/jvm/functions/Function1;)V
+	public final fun files (Lkotlin/jvm/functions/Function1;)V
+	public final fun functions (Lkotlin/jvm/functions/Function1;)V
+	public final fun layer (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun layered (Lkotlin/jvm/functions/Function1;)V
+	public final fun layeredArchitecture (Lkotlin/jvm/functions/Function1;)V
+	public final fun modules (Lkotlin/jvm/functions/Function1;)V
+	public final fun properties (Lkotlin/jvm/functions/Function1;)V
+	public final fun rule (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun slices (Lkotlin/jvm/functions/Function1;)V
+	public final fun sourceSet (Lio/github/baole/konture/SourceSetSelector;Lkotlin/jvm/functions/Function1;)V
+	public final fun sourceSet (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun sourceSet ([Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class io/github/baole/konture/RuleSetKt {
+	public static final fun architectureRules (Lkotlin/jvm/functions/Function1;)Lio/github/baole/konture/RuleSet;
 }
 
 public final class io/github/baole/konture/RuleSuppressionBuilder {

--- a/library/src/main/kotlin/io/github/baole/konture/KontureContext.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/KontureContext.kt
@@ -218,6 +218,36 @@ public class KontureContext(
         return ruleDef
     }
 
+    /**
+     * Imports and executes a reusable [RuleSet] inside this architecture validation context.
+     *
+     * Each declaration captured by the rule set (via [architectureRules]) is replayed
+     * into this context as if it had been declared inline. Multiple rule sets may be
+     * applied within a single `architecture { ... }` block, and rule sets may be
+     * combined with inline declarations and reused across separate blocks.
+     *
+     * Example:
+     * ```kotlin
+     * val cleanArchitecture = architectureRules {
+     *     classes {
+     *         that().resideInAPackage("com.example.domain..")
+     *         should().satisfy { !it.isAbstract }
+     *     }
+     * }
+     *
+     * architecture {
+     *     apply(cleanArchitecture)
+     * }
+     * ```
+     *
+     * @param ruleSet The reusable rule set to import and execute.
+     */
+    public fun apply(ruleSet: RuleSet) {
+        for (declaration in ruleSet.declarations) {
+            declaration()
+        }
+    }
+
     internal fun verifyAll() {
         /** Filter or assertion criteria for failures. */
         if (layerPolicies.isNotEmpty()) {

--- a/library/src/main/kotlin/io/github/baole/konture/RuleSet.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/RuleSet.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture
+
+/**
+ * A reusable, packageable bundle of architecture rules.
+ *
+ * Created by [architectureRules], a [RuleSet] captures rule-suite declarations
+ * (modules, classes, functions, properties, files, slices, layered architecture,
+ * layers, source-set policies, and named rules) without binding them to a
+ * specific [ProjectGraph]. The captured declarations are replayed into a
+ * [KontureContext] when [KontureContext.apply] is called inside an
+ * `architecture { ... }` block.
+ *
+ * Rule sets can be shared across projects, published as reusable Kotlin
+ * libraries, and composed freely within a single architecture block. Custom
+ * extension functions on [RuleSetBuilder] are the primary extension mechanism
+ * for team- or organization-specific policy bundles.
+ *
+ * Example:
+ * ```kotlin
+ * val cleanArchitecture = architectureRules {
+ *     classes {
+ *         that().resideInAPackage("com.example.domain..")
+ *         should().satisfy { !it.isAbstract }
+ *     }
+ *     layer("domain") {
+ *         selector { packages("com.example.domain..") }
+ *     }
+ * }
+ *
+ * architecture {
+ *     apply(cleanArchitecture)
+ * }
+ * ```
+ *
+ * @property declarations The captured declaration blocks, each scoped to a [KontureContext].
+ */
+public class RuleSet internal constructor(
+    internal val declarations: List<KontureContext.() -> Unit>,
+)
+
+/**
+ * Builder DSL for composing reusable [RuleSet] objects.
+ *
+ * Exposes the same suite-declaration surface as [KontureContext] (modules, classes,
+ * functions, properties, files, slices, layered architecture, layers, source-set
+ * policies, and named rules), capturing each declaration for later replay. This is
+ * the receiver type for the [architectureRules] builder block and for custom
+ * extension functions that bundle team-specific architecture policies.
+ *
+ * @see architectureRules
+ */
+@KontureDsl
+public class RuleSetBuilder {
+    private val declarations = mutableListOf<KontureContext.() -> Unit>()
+
+    internal fun build(): RuleSet = RuleSet(declarations.toList())
+
+    /**
+     * Captures a suite of module structure/dependency rules for later replay.
+     */
+    public fun modules(block: ModulesRuleBuilder.() -> Unit) {
+        declarations.add { modules(block) }
+    }
+
+    /**
+     * Captures a suite of class structure/dependency rules for later replay.
+     */
+    public fun classes(block: ClassesRuleBuilder.() -> Unit) {
+        declarations.add { classes(block) }
+    }
+
+    /**
+     * Captures a suite of function structure/dependency rules for later replay.
+     */
+    public fun functions(block: FunctionsRuleBuilder.() -> Unit) {
+        declarations.add { functions(block) }
+    }
+
+    /**
+     * Captures a suite of property structure/dependency rules for later replay.
+     */
+    public fun properties(block: PropertiesRuleBuilder.() -> Unit) {
+        declarations.add { properties(block) }
+    }
+
+    /**
+     * Captures a suite of file structure/dependency rules for later replay.
+     */
+    public fun files(block: FilesRuleBuilder.() -> Unit) {
+        declarations.add { files(block) }
+    }
+
+    /**
+     * Captures a suite of slice rules for later replay.
+     */
+    public fun slices(block: SlicesRuleBuilder.() -> Unit) {
+        declarations.add { slices(block) }
+    }
+
+    /**
+     * Captures a suite of layered-architecture rules for later replay.
+     */
+    public fun layeredArchitecture(block: LayeredArchitectureBuilder.() -> Unit) {
+        declarations.add { layeredArchitecture(block) }
+    }
+
+    /**
+     * Captures a first-class architectural layer with module/package selectors and
+     * explicit dependency boundaries for later replay.
+     *
+     * @param name The unique, human-readable name of the layer.
+     * @param block Declarative layer policy scoped to [ArchitectureLayerPolicy].
+     */
+    public fun layer(
+        name: String,
+        block: ArchitectureLayerPolicy.() -> Unit,
+    ) {
+        declarations.add { layer(name, block) }
+    }
+
+    /**
+     * Captures a first-class source-set architecture policy for source sets matching [name].
+     *
+     * @param name The source set name (e.g., `"commonMain"`).
+     * @param block Declarative source-set policy scoped to [ArchitectureSourceSetPolicy].
+     */
+    public fun sourceSet(
+        name: String,
+        block: ArchitectureSourceSetPolicy.() -> Unit,
+    ) {
+        declarations.add { sourceSet(name, block) }
+    }
+
+    /**
+     * Captures a first-class source-set architecture policy for source sets matching any of [names].
+     *
+     * @param names The source set names.
+     * @param block Declarative source-set policy scoped to [ArchitectureSourceSetPolicy].
+     */
+    public fun sourceSet(
+        vararg names: String,
+        block: ArchitectureSourceSetPolicy.() -> Unit,
+    ) {
+        declarations.add { sourceSet(names = names, block = block) }
+    }
+
+    /**
+     * Captures a first-class source-set architecture policy using a custom [SourceSetSelector].
+     *
+     * @param selector The selector identifying targeted source sets.
+     * @param block Declarative source-set policy scoped to [ArchitectureSourceSetPolicy].
+     */
+    public fun sourceSet(
+        selector: SourceSetSelector,
+        block: ArchitectureSourceSetPolicy.() -> Unit,
+    ) {
+        declarations.add { sourceSet(selector, block) }
+    }
+
+    /**
+     * Captures a nested, type-safe layered-architecture specification for later replay.
+     */
+    public fun layered(block: LayeredArchitectureDsl.() -> Unit) {
+        declarations.add { layered(block) }
+    }
+
+    /**
+     * Captures a named architecture rule with metadata and sub-rules for later replay.
+     *
+     * @param id Unique identifier for the rule.
+     */
+    public fun rule(
+        id: String,
+        block: RuleBuilder.() -> Unit,
+    ) {
+        declarations.add { rule(id, block) }
+    }
+}
+
+/**
+ * Creates a reusable [RuleSet] from the given [block].
+ *
+ * The block is scoped to [RuleSetBuilder], which mirrors the suite-declaration
+ * surface of [KontureContext]. Declarations are captured (not executed) and
+ * replayed later when the rule set is applied inside an `architecture { ... }`
+ * block via [KontureContext.apply].
+ *
+ * Custom extension functions on [RuleSetBuilder] are the recommended mechanism
+ * for bundling team- or organization-specific architecture policies into
+ * shareable, publishable rule sets.
+ *
+ * Example:
+ * ```kotlin
+ * val cleanArchitecture = architectureRules {
+ *     classes {
+ *         that().resideInAPackage("com.example.domain..")
+ *         should().satisfy { !it.isAbstract }
+ *     }
+ * }
+ *
+ * architecture {
+ *     apply(cleanArchitecture)
+ * }
+ * ```
+ *
+ * @param block DSL configuration block scoped to [RuleSetBuilder].
+ * @return A reusable [RuleSet] capturing the declared rules.
+ */
+public fun architectureRules(block: RuleSetBuilder.() -> Unit): RuleSet {
+    val builder = RuleSetBuilder()
+    builder.apply(block)
+    return builder.build()
+}

--- a/library/src/test/kotlin/io/github/baole/konture/RuleSetDslTest.kt
+++ b/library/src/test/kotlin/io/github/baole/konture/RuleSetDslTest.kt
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the reusable rule set DSL (issue #74).
+ *
+ * Covers [architectureRules] builder, [KontureContext.apply] of rule sets,
+ * custom extension functions on [RuleSetBuilder], and composition/reuse.
+ */
+class RuleSetDslTest : RuleBuildersTestBase() {
+    // ------------------------------------------------------------------
+    // AC 1: architectureRules { ... } creates reusable RuleSet objects
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `architectureRules creates a non-null RuleSet`() {
+        val ruleSet =
+            architectureRules {
+                classes {
+                    that().nameStartsWith("ClassA")
+                    should().inPackage("com.example")
+                }
+            }
+        assertTrue(ruleSet is RuleSet)
+    }
+
+    @Test
+    fun `empty architectureRules creates a valid RuleSet`() {
+        val ruleSet = architectureRules { }
+        assertTrue(ruleSet is RuleSet)
+    }
+
+    // ------------------------------------------------------------------
+    // AC 2: architecture { apply(ruleSet) } imports and executes rule sets
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `apply executes a passing rule set without throwing`() {
+        val ruleSet =
+            architectureRules {
+                classes {
+                    that().nameStartsWith("ClassA")
+                    should().inPackage("com.example")
+                }
+                modules {
+                    that().haveNamePath(":moduleA")
+                    should().satisfy { it.appliedPlugins.contains("kotlin") }
+                }
+            }
+        assertDoesNotThrow {
+            architecture {
+                apply(ruleSet)
+            }
+        }
+    }
+
+    @Test
+    fun `apply executes a failing rule set and throws AssertionError`() {
+        val ruleSet =
+            architectureRules {
+                classes {
+                    that().nameStartsWith("ClassA")
+                    should().inPackage("com.wrong")
+                }
+            }
+        val error =
+            assertThrows(AssertionError::class.java) {
+                architecture {
+                    apply(ruleSet)
+                }
+            }
+        assertTrue(error.message!!.contains("[classes]"))
+    }
+
+    @Test
+    fun `apply aggregates violations from multiple suites in the rule set`() {
+        val ruleSet =
+            architectureRules {
+                modules {
+                    that().haveNamePath(":moduleA")
+                    should().satisfy { it.appliedPlugins.contains("java") }
+                }
+                classes {
+                    that().nameStartsWith("ClassA")
+                    should().inPackage("com.wrong")
+                }
+            }
+        val error =
+            assertThrows(AssertionError::class.java) {
+                architecture {
+                    apply(ruleSet)
+                }
+            }
+        assertTrue(error.message!!.contains("[modules]"))
+        assertTrue(error.message!!.contains("[classes]"))
+        assertTrue(error.message!!.contains("2 suite(s)"))
+    }
+
+    // ------------------------------------------------------------------
+    // Rule sets containing layer policies
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `apply replays layer policies declared in the rule set`() {
+        val dependingClassA =
+            classA.copy(
+                imports = listOf("com.other.ClassC"),
+                referencedTypes = setOf("ClassC"),
+            )
+        val fileA = FileDeclaration("ClassA.kt", "com.example", classes = listOf(dependingClassA))
+        ProjectGraph(builds = mapOf(":" to listOf(moduleA.copy(files = listOf(fileA)), moduleB, moduleC)))
+            .also { ProjectGraph.setDefault(it) }
+
+        val ruleSet =
+            architectureRules {
+                layer("presentation") {
+                    selector { packages("com.example") }
+                    mayDependOn("domain")
+                }
+                layer("domain") {
+                    selector { packages("com.other") }
+                }
+            }
+        assertDoesNotThrow {
+            architecture {
+                apply(ruleSet)
+            }
+        }
+    }
+
+    @Test
+    fun `apply replays layer policies and detects violations`() {
+        val dependingClassA =
+            classA.copy(
+                imports = listOf("com.other.ClassC"),
+                referencedTypes = setOf("ClassC"),
+            )
+        val fileA = FileDeclaration("ClassA.kt", "com.example", classes = listOf(dependingClassA))
+        ProjectGraph(builds = mapOf(":" to listOf(moduleA.copy(files = listOf(fileA)), moduleB, moduleC)))
+            .also { ProjectGraph.setDefault(it) }
+
+        val ruleSet =
+            architectureRules {
+                layer("presentation") {
+                    selector { packages("com.example") }
+                    mayDependOn("core")
+                }
+                layer("domain") {
+                    selector { packages("com.other") }
+                }
+                layer("core") {
+                    selector { packages("com.core") }
+                }
+            }
+        val error =
+            assertThrows(AssertionError::class.java) {
+                architecture {
+                    apply(ruleSet)
+                }
+            }
+        assertTrue(error.message!!.contains("may only depend on layers [core]"))
+    }
+
+    // ------------------------------------------------------------------
+    // Support custom extension functions on RuleSetBuilder
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `custom extension function on RuleSetBuilder is supported`() {
+        val ruleSet =
+            architectureRules {
+                cleanArchitectureLayers()
+            }
+        // The custom extension declares two layers; with the base fixture graph
+        // (no cross-layer deps), it should pass.
+        assertDoesNotThrow {
+            architecture {
+                apply(ruleSet)
+            }
+        }
+    }
+
+    @Test
+    fun `custom extension function combining multiple rule types is supported`() {
+        val ruleSet =
+            architectureRules {
+                noAbstractClasses()
+            }
+        // moduleC has ClassC which is abstract — should fail.
+        val error =
+            assertThrows(AssertionError::class.java) {
+                architecture {
+                    apply(ruleSet)
+                }
+            }
+        assertTrue(error.message!!.contains("[classes]"))
+    }
+
+    // ------------------------------------------------------------------
+    // Composition & reuse
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `multiple rule sets can be composed in a single architecture block`() {
+        val passingRules =
+            architectureRules {
+                classes {
+                    that().nameStartsWith("ClassA")
+                    should().inPackage("com.example")
+                }
+            }
+        val failingRules =
+            architectureRules {
+                modules {
+                    that().haveNamePath(":moduleA")
+                    should().satisfy { it.appliedPlugins.contains("java") }
+                }
+            }
+        val error =
+            assertThrows(AssertionError::class.java) {
+                architecture {
+                    apply(passingRules)
+                    apply(failingRules)
+                }
+            }
+        assertTrue(error.message!!.contains("[modules]"))
+    }
+
+    @Test
+    fun `a rule set can be reused across multiple architecture blocks`() {
+        val ruleSet =
+            architectureRules {
+                classes {
+                    that().nameStartsWith("ClassA")
+                    should().inPackage("com.example")
+                }
+            }
+        // First use
+        assertDoesNotThrow {
+            architecture {
+                apply(ruleSet)
+            }
+        }
+        // Second use — same rule set object, should still work
+        assertDoesNotThrow {
+            architecture {
+                apply(ruleSet)
+            }
+        }
+    }
+
+    @Test
+    fun `rule set can combine inline rules and applied rule sets`() {
+        val sharedRules =
+            architectureRules {
+                modules {
+                    that().haveNamePath(":moduleA")
+                    should().satisfy { it.appliedPlugins.contains("kotlin") }
+                }
+            }
+        assertDoesNotThrow {
+            architecture {
+                apply(sharedRules)
+                classes {
+                    that().nameStartsWith("ClassA")
+                    should().inPackage("com.example")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `apply with empty rule set does nothing`() {
+        val empty = architectureRules { }
+        assertDoesNotThrow {
+            architecture {
+                apply(empty)
+                classes {
+                    that().nameStartsWith("ClassA")
+                    should().inPackage("com.example")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `named rules inside a rule set are replayed correctly`() {
+        val ruleSet =
+            architectureRules {
+                rule("custom-no-abstract") {
+                    description = "No abstract classes"
+                    classes {
+                        that().inPackage("com.other")
+                        should().satisfy { !it.isAbstract }
+                    }
+                }
+            }
+        val error =
+            assertThrows(AssertionError::class.java) {
+                architecture {
+                    apply(ruleSet)
+                }
+            }
+        assertTrue(error.message!!.contains("custom-no-abstract"))
+    }
+}
+
+// ------------------------------------------------------------------
+// Custom extension functions on RuleSetBuilder
+// ------------------------------------------------------------------
+
+/** Example custom rule-set extension: declares clean-architecture-style layers. */
+private fun RuleSetBuilder.cleanArchitectureLayers() {
+    layer("presentation") {
+        selector { packages("com.example") }
+    }
+    layer("domain") {
+        selector { packages("com.other") }
+    }
+}
+
+/** Example custom rule-set extension: forbids abstract classes. */
+private fun RuleSetBuilder.noAbstractClasses() {
+    classes {
+        that().inPackage("com.other")
+        should().satisfy { !it.isAbstract }
+    }
+}


### PR DESCRIPTION
## Reusable Rule Sets & Packageable Policies

Closes #74

### Summary

Adds the `architectureRules { ... }` builder and `architecture { apply(ruleSet) }` mechanism so teams can bundle architectural rules into reusable rule sets that can be shared across projects or published as reusable Kotlin libraries.

### Changes

**New — `library/src/main/kotlin/io/github/baole/konture/RuleSet.kt`:**
- `RuleSet` — holds captured declarations as `List<KontureContext.() -> Unit>`
- `RuleSetBuilder` — `@KontureDsl`-annotated builder mirroring `KontureContext`'s full suite-declaration surface (modules, classes, functions, properties, files, slices, layeredArchitecture, layer, sourceSet, layered, rule), each capturing its args as a replay lambda
- `architectureRules(block)` — top-level entry point that creates a `RuleSet`

**Modified — `library/src/main/kotlin/io/github/baole/konture/KontureContext.kt`:**
- `apply(ruleSet: RuleSet)` — replays captured declarations into the current context

**New — `library/src/test/kotlin/io/github/baole/konture/RuleSetDslTest.kt`:**
- 14 tests covering all 4 acceptance criteria

**Modified — `library/api/library.api`:**
- Regenerated ABI dump for the new public symbols

### Usage

```kotlin
val cleanArchitecture = architectureRules {
    classes {
        that().resideInAPackage("com.example.domain..")
        should().satisfy { !it.isAbstract }
    }
    layer("domain") {
        selector { packages("com.example.domain..") }
    }
}

architecture {
    apply(cleanArchitecture)
}
```

Custom extension functions on `RuleSetBuilder` are the primary extension mechanism for organization-specific policy bundles:

```kotlin
fun RuleSetBuilder.cleanArchitectureLayers() {
    layer("presentation") { selector { packages("com.acme.presentation..") } }
    layer("domain") { selector { packages("com.acme.domain..") } }
}

val rules = architectureRules { cleanArchitectureLayers() }
```

### Acceptance Criteria

- [x] `architectureRules { ... }` builder creates reusable `RuleSet` objects
- [x] `architecture { apply(ruleSet) }` imports and executes rule sets
- [x] Support custom extension functions on `RuleSetBuilder`
- [x] Unit tests for rule set reuse and composition in `:library:test` (14 tests)

### Verification

```bash
./gradlew -q :library:test
```

Full `:library:check` gate passes green (ktlint, detekt, tests, jacoco coverage, ABI verification).