### PR TITLE
feat(issue-#74): Reusable Rule Sets & Packageable Policies

### DIFF
--- a/library/api/library.api
+++ b/library/api/library.api
@@ -44,6 +44,15 @@ public final class io/github/baole/konture/ArchitectureLayerPolicy {
 	public final fun selector (Lkotlin/jvm/functions/Function1;)V
 }
 
+public final class io/github/baole/konture/ArchitectureRulesKt {
+	public static final fun architectureRules (Lio/github/baole/konture/Konture;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/github/baole/konture/RuleSet;
+	public static final fun architectureRules (Lio/github/baole/konture/Konture;Lkotlin/jvm/functions/Function1;)Lio/github/baole/konture/RuleSet;
+	public static final fun architectureRules (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/github/baole/konture/RuleSet;
+	public static final fun architectureRules (Lkotlin/jvm/functions/Function1;)Lio/github/baole/konture/RuleSet;
+	public static synthetic fun architectureRules$default (Lio/github/baole/konture/Konture;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/github/baole/konture/RuleSet;
+	public static synthetic fun architectureRules$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/github/baole/konture/RuleSet;
+}
+
 public final class io/github/baole/konture/ArchitectureSourceSetPolicy {
 	public final fun getLabel ()Ljava/lang/String;
 	public final fun getSelector ()Lio/github/baole/konture/SourceSetSelector;
@@ -3421,8 +3430,18 @@ public final class io/github/baole/konture/Konture {
 
 public final class io/github/baole/konture/KontureContext {
 	public fun <init> (Lio/github/baole/konture/ProjectGraph;)V
+	public final fun apply (Lio/github/baole/konture/RuleDefinition;)V
+	public final fun apply (Lio/github/baole/konture/RuleSet;)V
+	public final fun apply (Ljava/lang/Iterable;)V
+	public final fun apply ([Lio/github/baole/konture/RuleDefinition;)V
+	public final fun apply ([Lio/github/baole/konture/RuleSet;)V
+	public final fun assertNoCycles (Z)V
+	public static synthetic fun assertNoCycles$default (Lio/github/baole/konture/KontureContext;ZILjava/lang/Object;)V
+	public final fun classes (Lio/github/baole/konture/SourceSetSelector;Lkotlin/jvm/functions/Function1;)V
 	public final fun classes (Lkotlin/jvm/functions/Function1;)V
+	public final fun files (Lio/github/baole/konture/SourceSetSelector;Lkotlin/jvm/functions/Function1;)V
 	public final fun files (Lkotlin/jvm/functions/Function1;)V
+	public final fun functions (Lio/github/baole/konture/SourceSetSelector;Lkotlin/jvm/functions/Function1;)V
 	public final fun functions (Lkotlin/jvm/functions/Function1;)V
 	public final fun getClasses ()Lio/github/baole/konture/KontureScope;
 	public final fun getFiles ()Lio/github/baole/konture/KontureFileScope;
@@ -3432,9 +3451,14 @@ public final class io/github/baole/konture/KontureContext {
 	public final fun layer (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public final fun layered (Lkotlin/jvm/functions/Function1;)V
 	public final fun layeredArchitecture (Lkotlin/jvm/functions/Function1;)V
+	public final fun modules (Lio/github/baole/konture/SourceSetSelector;Lkotlin/jvm/functions/Function1;)V
 	public final fun modules (Lkotlin/jvm/functions/Function1;)V
+	public final fun noCycles (Z)V
+	public static synthetic fun noCycles$default (Lio/github/baole/konture/KontureContext;ZILjava/lang/Object;)V
+	public final fun properties (Lio/github/baole/konture/SourceSetSelector;Lkotlin/jvm/functions/Function1;)V
 	public final fun properties (Lkotlin/jvm/functions/Function1;)V
 	public final fun rule (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/github/baole/konture/RuleDefinition;
+	public final fun slices (Lio/github/baole/konture/SourceSetSelector;Lkotlin/jvm/functions/Function1;)V
 	public final fun slices (Ljava/lang/String;)Lio/github/baole/konture/KontureSliceScope;
 	public final fun slices (Lkotlin/jvm/functions/Function1;)V
 	public final fun sourceSet (Lio/github/baole/konture/SourceSetSelector;Lkotlin/jvm/functions/Function1;)V
@@ -5397,6 +5421,52 @@ public final class io/github/baole/konture/RuleDefinition {
 
 public final class io/github/baole/konture/RuleDslKt {
 	public static final fun rule (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/github/baole/konture/RuleDefinition;
+}
+
+public final class io/github/baole/konture/RuleSet {
+	public final fun check ()V
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun plus (Lio/github/baole/konture/RuleSet;)Lio/github/baole/konture/RuleSet;
+	public final fun verify ()V
+}
+
+public final class io/github/baole/konture/RuleSetBuilder {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun apply (Lio/github/baole/konture/RuleDefinition;)V
+	public final fun apply (Lio/github/baole/konture/RuleSet;)V
+	public final fun apply (Ljava/lang/Iterable;)V
+	public final fun apply ([Lio/github/baole/konture/RuleDefinition;)V
+	public final fun apply ([Lio/github/baole/konture/RuleSet;)V
+	public final fun assertNoCycles (Z)V
+	public static synthetic fun assertNoCycles$default (Lio/github/baole/konture/RuleSetBuilder;ZILjava/lang/Object;)V
+	public final fun classes (Lio/github/baole/konture/SourceSetSelector;Lkotlin/jvm/functions/Function1;)V
+	public final fun classes (Lkotlin/jvm/functions/Function1;)V
+	public final fun files (Lio/github/baole/konture/SourceSetSelector;Lkotlin/jvm/functions/Function1;)V
+	public final fun files (Lkotlin/jvm/functions/Function1;)V
+	public final fun functions (Lio/github/baole/konture/SourceSetSelector;Lkotlin/jvm/functions/Function1;)V
+	public final fun functions (Lkotlin/jvm/functions/Function1;)V
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun layer (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun layered (Lkotlin/jvm/functions/Function1;)V
+	public final fun layeredArchitecture (Lkotlin/jvm/functions/Function1;)V
+	public final fun modules (Lio/github/baole/konture/SourceSetSelector;Lkotlin/jvm/functions/Function1;)V
+	public final fun modules (Lkotlin/jvm/functions/Function1;)V
+	public final fun noCycles (Z)V
+	public static synthetic fun noCycles$default (Lio/github/baole/konture/RuleSetBuilder;ZILjava/lang/Object;)V
+	public final fun properties (Lio/github/baole/konture/SourceSetSelector;Lkotlin/jvm/functions/Function1;)V
+	public final fun properties (Lkotlin/jvm/functions/Function1;)V
+	public final fun rule (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun setDescription (Ljava/lang/String;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun slices (Lio/github/baole/konture/SourceSetSelector;Lkotlin/jvm/functions/Function1;)V
+	public final fun slices (Lkotlin/jvm/functions/Function1;)V
+	public final fun sourceSet (Lio/github/baole/konture/SourceSetSelector;Lkotlin/jvm/functions/Function1;)V
+	public final fun sourceSet (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun sourceSet ([Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/github/baole/konture/RuleSuppressionBuilder {

--- a/library/src/main/kotlin/io/github/baole/konture/ArchitectureRules.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/ArchitectureRules.kt
@@ -51,4 +51,5 @@ public fun Konture.architectureRules(
  * @param block DSL configuration block scoped to [RuleSetBuilder].
  * @return Reusable [RuleSet].
  */
-public fun Konture.architectureRules(block: RuleSetBuilder.() -> Unit): RuleSet = io.github.baole.konture.architectureRules(name = null, block = block)
+public fun Konture.architectureRules(block: RuleSetBuilder.() -> Unit): RuleSet =
+    io.github.baole.konture.architectureRules(name = null, block = block)

--- a/library/src/main/kotlin/io/github/baole/konture/ArchitectureRules.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/ArchitectureRules.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc (@baole)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture
+
+/**
+ * Top-level builder function for defining a reusable, named [RuleSet].
+ *
+ * @param name Optional identifier or name for the rule set.
+ * @param block DSL configuration block scoped to [RuleSetBuilder].
+ * @return Reusable [RuleSet].
+ */
+public fun architectureRules(
+    name: String? = null,
+    block: RuleSetBuilder.() -> Unit,
+): RuleSet {
+    val builder = RuleSetBuilder(name).apply(block)
+    return RuleSet(
+        name = builder.name,
+        description = builder.description,
+        actions = builder.actions.toList(),
+    )
+}
+
+/**
+ * Top-level builder function for defining a reusable [RuleSet].
+ *
+ * @param block DSL configuration block scoped to [RuleSetBuilder].
+ * @return Reusable [RuleSet].
+ */
+public fun architectureRules(block: RuleSetBuilder.() -> Unit): RuleSet = architectureRules(name = null, block = block)
+
+/**
+ * Builder function on [Konture] for defining a reusable, named [RuleSet].
+ *
+ * @param name Optional identifier or name for the rule set.
+ * @param block DSL configuration block scoped to [RuleSetBuilder].
+ * @return Reusable [RuleSet].
+ */
+public fun Konture.architectureRules(
+    name: String? = null,
+    block: RuleSetBuilder.() -> Unit,
+): RuleSet = io.github.baole.konture.architectureRules(name, block)
+
+/**
+ * Builder function on [Konture] for defining a reusable [RuleSet].
+ *
+ * @param block DSL configuration block scoped to [RuleSetBuilder].
+ * @return Reusable [RuleSet].
+ */
+public fun Konture.architectureRules(block: RuleSetBuilder.() -> Unit): RuleSet = io.github.baole.konture.architectureRules(name = null, block = block)

--- a/library/src/main/kotlin/io/github/baole/konture/KontureContext.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/KontureContext.kt
@@ -218,6 +218,129 @@ public class KontureContext(
         return ruleDef
     }
 
+    /**
+     * Imports and executes all rules declared inside [ruleSet] in this architecture validation context.
+     */
+    public fun apply(ruleSet: RuleSet) {
+        ruleSet.applyTo(this)
+    }
+
+    /**
+     * Imports and executes multiple [RuleSet] instances in this architecture validation context.
+     */
+    public fun apply(vararg ruleSets: RuleSet) {
+        ruleSets.forEach { it.applyTo(this) }
+    }
+
+    /**
+     * Imports and executes a collection of [RuleSet] instances in this architecture validation context.
+     */
+    public fun apply(ruleSets: Iterable<RuleSet>) {
+        ruleSets.forEach { it.applyTo(this) }
+    }
+
+    /**
+     * Imports and executes a [RuleDefinition] inside this architecture validation context.
+     */
+    public fun apply(rule: RuleDefinition) {
+        addSuite(rule.metadata.id) { rule.check() }
+    }
+
+    /**
+     * Imports and executes multiple [RuleDefinition] instances inside this architecture validation context.
+     */
+    public fun apply(vararg rules: RuleDefinition) {
+        rules.forEach { apply(it) }
+    }
+
+    /**
+     * Declares a suite of module structure/dependency rules scoped to specific source sets.
+     */
+    public fun modules(
+        sourceSets: SourceSetSelector,
+        block: ModulesRuleBuilder.() -> Unit,
+    ) {
+        val builder = ModulesRuleBuilder(projectGraph, sourceSets)
+        builder.apply(block)
+        addSuite("modules") { builder.check() }
+    }
+
+    /**
+     * Declares a suite of class structure/dependency rules scoped to specific source sets.
+     */
+    public fun classes(
+        sourceSets: SourceSetSelector,
+        block: ClassesRuleBuilder.() -> Unit,
+    ) {
+        val builder = ClassesRuleBuilder(projectGraph, sourceSets)
+        builder.apply(block)
+        addSuite("classes") { builder.check() }
+    }
+
+    /**
+     * Declares a suite of function structure/dependency rules scoped to specific source sets.
+     */
+    public fun functions(
+        sourceSets: SourceSetSelector,
+        block: FunctionsRuleBuilder.() -> Unit,
+    ) {
+        val builder = FunctionsRuleBuilder(projectGraph, sourceSets)
+        builder.apply(block)
+        addSuite("functions") { builder.check() }
+    }
+
+    /**
+     * Declares a suite of property structure/dependency rules scoped to specific source sets.
+     */
+    public fun properties(
+        sourceSets: SourceSetSelector,
+        block: PropertiesRuleBuilder.() -> Unit,
+    ) {
+        val builder = PropertiesRuleBuilder(projectGraph, sourceSets)
+        builder.apply(block)
+        addSuite("properties") { builder.check() }
+    }
+
+    /**
+     * Declares a suite of file structure/dependency rules scoped to specific source sets.
+     */
+    public fun files(
+        sourceSets: SourceSetSelector,
+        block: FilesRuleBuilder.() -> Unit,
+    ) {
+        val builder = FilesRuleBuilder(projectGraph, sourceSets)
+        builder.apply(block)
+        addSuite("files") { builder.check() }
+    }
+
+    /**
+     * Declares a suite of slice rules scoped to specific source sets.
+     */
+    public fun slices(
+        sourceSets: SourceSetSelector,
+        block: SlicesRuleBuilder.() -> Unit,
+    ) {
+        val builder = SlicesRuleBuilder(projectGraph, sourceSets)
+        builder.apply(block)
+        addSuite("slices") { builder.check() }
+    }
+
+    /**
+     * Verifies that there are no module dependency cycles in the project.
+     *
+     * @param includeTestConfigurations if true, test-related dependency configurations will also be analyzed.
+     */
+    public fun noCycles(includeTestConfigurations: Boolean = false) {
+        addSuite("noCycles") { projectGraph.assertNoCycles(includeTestConfigurations) }
+    }
+
+    /**
+     * Alias for [noCycles].
+     */
+    public fun assertNoCycles(includeTestConfigurations: Boolean = false) {
+        noCycles(includeTestConfigurations)
+    }
+
     internal fun verifyAll() {
         /** Filter or assertion criteria for failures. */
         if (layerPolicies.isNotEmpty()) {

--- a/library/src/main/kotlin/io/github/baole/konture/RuleSet.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/RuleSet.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc (@baole)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture
+
+/**
+ * Encapsulates a reusable collection of architectural rules and policies.
+ *
+ * Rule sets can be defined using [architectureRules], composed using [plus] or [apply],
+ * executed standalone via [check] or [verify], or imported into an [architecture] block.
+ *
+ * @property name Optional human-readable name or identifier for this rule set.
+ * @property description Optional human-readable rationale or description of the rule set.
+ */
+public class RuleSet internal constructor(
+    public val name: String? = null,
+    public val description: String? = null,
+    internal val actions: List<(KontureContext) -> Unit>,
+) {
+    /**
+     * Executes all rules and assertions in this rule set against the default [ProjectGraph].
+     *
+     * @throws AssertionError if any architectural violations occur.
+     */
+    public fun check() {
+        Konture.architecture {
+            apply(this@RuleSet)
+        }
+    }
+
+    /**
+     * Alias for [check].
+     */
+    public fun verify() {
+        check()
+    }
+
+    /**
+     * Combines this rule set with [other] into a new composite [RuleSet].
+     *
+     * @param other Another [RuleSet] to combine with this one.
+     * @return A new [RuleSet] containing rules from both sets.
+     */
+    public operator fun plus(other: RuleSet): RuleSet {
+        val combinedName =
+            listOfNotNull(name, other.name)
+                .joinToString(" + ")
+                .ifEmpty { null }
+        val combinedDesc =
+            listOfNotNull(description, other.description)
+                .joinToString("; ")
+                .ifEmpty { null }
+        return RuleSet(
+            name = combinedName,
+            description = combinedDesc,
+            actions = this.actions + other.actions,
+        )
+    }
+
+    internal fun applyTo(context: KontureContext) {
+        actions.forEach { action -> action(context) }
+    }
+}

--- a/library/src/main/kotlin/io/github/baole/konture/RuleSetBuilder.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/RuleSetBuilder.kt
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc (@baole)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture
+
+/**
+ * DSL builder for configuring a reusable [RuleSet].
+ *
+ * Allows declaring module, class, function, property, file, slice, and layer rules,
+ * importing existing rule sets, and writing custom extension functions.
+ *
+ * @property name Optional human-readable name or identifier for this rule set.
+ */
+@KontureDsl
+public class RuleSetBuilder(
+    public var name: String? = null,
+) {
+    /** Optional human-readable explanation or rationale for this rule set. */
+    public var description: String? = null
+
+    internal val actions = mutableListOf<(KontureContext) -> Unit>()
+
+    /**
+     * Imports and executes another [RuleSet] within this rule set.
+     */
+    public fun apply(ruleSet: RuleSet) {
+        actions.add { context -> context.apply(ruleSet) }
+    }
+
+    /**
+     * Imports and executes multiple [RuleSet] instances within this rule set.
+     */
+    public fun apply(vararg ruleSets: RuleSet) {
+        ruleSets.forEach { apply(it) }
+    }
+
+    /**
+     * Imports and executes a collection of [RuleSet] instances within this rule set.
+     */
+    public fun apply(ruleSets: Iterable<RuleSet>) {
+        ruleSets.forEach { apply(it) }
+    }
+
+    /**
+     * Imports and executes a [RuleDefinition] within this rule set.
+     */
+    public fun apply(rule: RuleDefinition) {
+        actions.add { context -> context.apply(rule) }
+    }
+
+    /**
+     * Imports and executes multiple [RuleDefinition] instances within this rule set.
+     */
+    public fun apply(vararg rules: RuleDefinition) {
+        rules.forEach { apply(it) }
+    }
+
+    /**
+     * Declares a named architecture rule with metadata and sub-rules inside this rule set.
+     */
+    public fun rule(
+        id: String,
+        block: RuleBuilder.() -> Unit,
+    ) {
+        actions.add { context -> context.rule(id, block) }
+    }
+
+    /**
+     * Declares a suite of module structure/dependency rules inside this rule set.
+     */
+    public fun modules(block: ModulesRuleBuilder.() -> Unit) {
+        actions.add { context -> context.modules(block) }
+    }
+
+    /**
+     * Declares a suite of module structure/dependency rules scoped to specific source sets.
+     */
+    public fun modules(
+        sourceSets: SourceSetSelector,
+        block: ModulesRuleBuilder.() -> Unit,
+    ) {
+        actions.add { context -> context.modules(sourceSets, block) }
+    }
+
+    /**
+     * Declares a suite of class structure/dependency rules inside this rule set.
+     */
+    public fun classes(block: ClassesRuleBuilder.() -> Unit) {
+        actions.add { context -> context.classes(block) }
+    }
+
+    /**
+     * Declares a suite of class structure/dependency rules scoped to specific source sets.
+     */
+    public fun classes(
+        sourceSets: SourceSetSelector,
+        block: ClassesRuleBuilder.() -> Unit,
+    ) {
+        actions.add { context -> context.classes(sourceSets, block) }
+    }
+
+    /**
+     * Declares a suite of function structure/dependency rules inside this rule set.
+     */
+    public fun functions(block: FunctionsRuleBuilder.() -> Unit) {
+        actions.add { context -> context.functions(block) }
+    }
+
+    /**
+     * Declares a suite of function structure/dependency rules scoped to specific source sets.
+     */
+    public fun functions(
+        sourceSets: SourceSetSelector,
+        block: FunctionsRuleBuilder.() -> Unit,
+    ) {
+        actions.add { context -> context.functions(sourceSets, block) }
+    }
+
+    /**
+     * Declares a suite of property structure/dependency rules inside this rule set.
+     */
+    public fun properties(block: PropertiesRuleBuilder.() -> Unit) {
+        actions.add { context -> context.properties(block) }
+    }
+
+    /**
+     * Declares a suite of property structure/dependency rules scoped to specific source sets.
+     */
+    public fun properties(
+        sourceSets: SourceSetSelector,
+        block: PropertiesRuleBuilder.() -> Unit,
+    ) {
+        actions.add { context -> context.properties(sourceSets, block) }
+    }
+
+    /**
+     * Declares a suite of file structure/dependency rules inside this rule set.
+     */
+    public fun files(block: FilesRuleBuilder.() -> Unit) {
+        actions.add { context -> context.files(block) }
+    }
+
+    /**
+     * Declares a suite of file structure/dependency rules scoped to specific source sets.
+     */
+    public fun files(
+        sourceSets: SourceSetSelector,
+        block: FilesRuleBuilder.() -> Unit,
+    ) {
+        actions.add { context -> context.files(sourceSets, block) }
+    }
+
+    /**
+     * Declares a suite of slice rules inside this rule set.
+     */
+    public fun slices(block: SlicesRuleBuilder.() -> Unit) {
+        actions.add { context -> context.slices(block) }
+    }
+
+    /**
+     * Declares a suite of slice rules scoped to specific source sets.
+     */
+    public fun slices(
+        sourceSets: SourceSetSelector,
+        block: SlicesRuleBuilder.() -> Unit,
+    ) {
+        actions.add { context -> context.slices(sourceSets, block) }
+    }
+
+    /**
+     * Declares a suite of layered-architecture rules inside this rule set.
+     */
+    public fun layeredArchitecture(block: LayeredArchitectureBuilder.() -> Unit) {
+        actions.add { context -> context.layeredArchitecture(block) }
+    }
+
+    /**
+     * Declares a nested, type-safe layered-architecture specification inside this rule set.
+     */
+    public fun layered(block: LayeredArchitectureDsl.() -> Unit) {
+        actions.add { context -> context.layered(block) }
+    }
+
+    /**
+     * Declares a first-class architectural layer with module/package selectors and
+     * explicit dependency boundaries inside this rule set.
+     */
+    public fun layer(
+        name: String,
+        block: ArchitectureLayerPolicy.() -> Unit,
+    ) {
+        actions.add { context -> context.layer(name, block) }
+    }
+
+    /**
+     * Declares a first-class source-set architecture policy for source sets matching [name].
+     */
+    public fun sourceSet(
+        name: String,
+        block: ArchitectureSourceSetPolicy.() -> Unit,
+    ) {
+        actions.add { context -> context.sourceSet(name, block) }
+    }
+
+    /**
+     * Declares a first-class source-set architecture policy for source sets matching any of [names].
+     */
+    public fun sourceSet(
+        vararg names: String,
+        block: ArchitectureSourceSetPolicy.() -> Unit,
+    ) {
+        actions.add { context -> context.sourceSet(*names, block = block) }
+    }
+
+    /**
+     * Declares a first-class source-set architecture policy using a custom [SourceSetSelector].
+     */
+    public fun sourceSet(
+        selector: SourceSetSelector,
+        block: ArchitectureSourceSetPolicy.() -> Unit,
+    ) {
+        actions.add { context -> context.sourceSet(selector, block) }
+    }
+
+    /**
+     * Verifies that there are no module dependency cycles in the project.
+     *
+     * @param includeTestConfigurations if true, test-related dependency configurations will also be analyzed.
+     */
+    public fun noCycles(includeTestConfigurations: Boolean = false) {
+        actions.add { context -> context.noCycles(includeTestConfigurations) }
+    }
+
+    /**
+     * Alias for [noCycles].
+     */
+    public fun assertNoCycles(includeTestConfigurations: Boolean = false) {
+        noCycles(includeTestConfigurations)
+    }
+}

--- a/library/src/test/kotlin/io/github/baole/konture/RuleSetTest.kt
+++ b/library/src/test/kotlin/io/github/baole/konture/RuleSetTest.kt
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc (@baole)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RuleSetTest : RuleBuildersTestBase() {
+    private fun graphWith(modules: List<Module>): ProjectGraph {
+        return ProjectGraph(builds = mapOf(":" to modules)).also { ProjectGraph.setDefault(it) }
+    }
+
+    @Test
+    fun `architectureRules builder creates RuleSet with metadata`() {
+        val ruleSet =
+            architectureRules("clean-architecture") {
+                description = "Enforces clean architecture boundaries"
+                classes {
+                    that().haveNameStartingWith("ClassA")
+                    should().resideInAPackage("com.example")
+                }
+            }
+
+        assertEquals("clean-architecture", ruleSet.name)
+        assertEquals("Enforces clean architecture boundaries", ruleSet.description)
+    }
+
+    @Test
+    fun `architecture block executes applied RuleSet successfully`() {
+        val cleanArchitecture =
+            architectureRules {
+                classes {
+                    that().haveNameStartingWith("ClassA")
+                    should().resideInAPackage("com.example")
+                }
+                files {
+                    that().haveNameEndingWith("ClassB.kt")
+                    should().resideInAPackage("com.example")
+                }
+                noCycles()
+            }
+
+        assertDoesNotThrow {
+            architecture {
+                apply(cleanArchitecture)
+            }
+        }
+    }
+
+    @Test
+    fun `RuleSet check and verify run standalone`() {
+        val passingRuleSet =
+            architectureRules("passing-suite") {
+                classes {
+                    that().haveNameStartingWith("ClassA")
+                    should().resideInAPackage("com.example")
+                }
+            }
+
+        assertDoesNotThrow {
+            passingRuleSet.check()
+        }
+
+        assertDoesNotThrow {
+            passingRuleSet.verify()
+        }
+    }
+
+    @Test
+    fun `custom extension functions on RuleSetBuilder work seamlessly`() {
+        // Define custom extension functions on RuleSetBuilder
+        fun RuleSetBuilder.domainIsolation() {
+            classes {
+                that().haveNameStartingWith("ClassA")
+                should().resideInAPackage("com.example")
+            }
+        }
+
+        fun RuleSetBuilder.repositoryInterfaces() {
+            classes {
+                allowEmpty().that().haveNameEndingWith("Repository")
+                should().beInterfaces()
+            }
+        }
+
+        val cleanArchitecture =
+            architectureRules {
+                domainIsolation()
+                repositoryInterfaces()
+                noCycles()
+            }
+
+        assertDoesNotThrow {
+            architecture {
+                apply(cleanArchitecture)
+            }
+        }
+    }
+
+    @Test
+    fun `failing rules in RuleSet trigger aggregated assertion error`() {
+        val strictArchitecture =
+            architectureRules("strict") {
+                classes {
+                    that().haveNameStartingWith("ClassA")
+                    should().resideInAPackage("com.nonexistent")
+                }
+                modules {
+                    that().haveNamePath(":moduleA")
+                    should().satisfy { module -> module.appliedPlugins.contains("nonexistent-plugin") }
+                }
+            }
+
+        val error =
+            assertThrows(AssertionError::class.java) {
+                architecture {
+                    apply(strictArchitecture)
+                }
+            }
+
+        assertTrue(error.message!!.contains("[classes]"))
+        assertTrue(error.message!!.contains("[modules]"))
+        assertTrue(error.message!!.contains("2 suite(s)"))
+    }
+
+    @Test
+    fun `RuleSet composition with plus operator combines rule suites`() {
+        val ruleSetA =
+            architectureRules("setA") {
+                classes {
+                    that().haveNameStartingWith("ClassA")
+                    should().resideInAPackage("com.example")
+                }
+            }
+
+        val ruleSetB =
+            architectureRules("setB") {
+                files {
+                    that().haveNameEndingWith("ClassB.kt")
+                    should().resideInAPackage("com.example")
+                }
+            }
+
+        val combined = ruleSetA + ruleSetB
+
+        assertEquals("setA + setB", combined.name)
+
+        assertDoesNotThrow {
+            architecture {
+                apply(combined)
+            }
+        }
+
+        assertDoesNotThrow {
+            combined.check()
+        }
+    }
+
+    @Test
+    fun `RuleSet composition via apply imports nested rule sets`() {
+        val innerRules =
+            architectureRules {
+                classes {
+                    that().haveNameStartingWith("ClassA")
+                    should().resideInAPackage("com.example")
+                }
+            }
+
+        val outerRules =
+            architectureRules {
+                apply(innerRules)
+                files {
+                    that().haveNameEndingWith("ClassB.kt")
+                    should().resideInAPackage("com.example")
+                }
+            }
+
+        assertDoesNotThrow {
+            outerRules.check()
+        }
+    }
+
+    @Test
+    fun `apply overloads for vararg, collection, and RuleDefinition`() {
+        val ruleSet1 =
+            architectureRules {
+                classes {
+                    that().haveNameStartingWith("ClassA")
+                    should().resideInAPackage("com.example")
+                }
+            }
+
+        val ruleSet2 =
+            architectureRules {
+                files {
+                    that().haveNameEndingWith("ClassB.kt")
+                    should().resideInAPackage("com.example")
+                }
+            }
+
+        val standaloneRule =
+            rule("standalone-class-check") {
+                classes {
+                    that().haveNameStartingWith("ClassA")
+                    should().resideInAPackage("com.example")
+                }
+            }
+
+        // Test vararg apply in architecture block
+        assertDoesNotThrow {
+            architecture {
+                apply(ruleSet1, ruleSet2)
+                apply(standaloneRule)
+            }
+        }
+
+        // Test collection apply in architecture block
+        assertDoesNotThrow {
+            architecture {
+                apply(listOf(ruleSet1, ruleSet2))
+            }
+        }
+
+        // Test apply in RuleSetBuilder
+        val composite =
+            architectureRules {
+                apply(ruleSet1, ruleSet2)
+                apply(listOf(ruleSet1))
+                apply(standaloneRule)
+            }
+
+        assertDoesNotThrow {
+            composite.check()
+        }
+    }
+
+    @Test
+    fun `architectureRules supports layers, slices, and source sets`() {
+        graphWith(listOf(moduleA, moduleB, moduleC))
+
+        val layeredPolicy =
+            architectureRules("layered-policy") {
+                layer("presentation") {
+                    selector { packages("com.example") }
+                }
+                layer("domain") {
+                    selector { packages("com.other") }
+                }
+                slices(SourceSets.production()) {
+                    allowEmpty().matching("com.(*)..").should().beFreeOfCycles()
+                }
+                sourceSet("commonMain") {
+                    mayDependOn("commonMain")
+                }
+            }
+
+        assertDoesNotThrow {
+            architecture {
+                apply(layeredPolicy)
+            }
+        }
+    }
+
+    @Test
+    fun `Konture architectureRules extension methods work identically`() {
+        val ruleSet =
+            Konture.architectureRules("konture-rules") {
+                classes {
+                    that().haveNameStartingWith("ClassA")
+                    should().resideInAPackage("com.example")
+                }
+            }
+
+        assertEquals("konture-rules", ruleSet.name)
+        assertDoesNotThrow {
+            ruleSet.check()
+        }
+    }
+}


### PR DESCRIPTION
Closes #74

## Summary of Changes
- Introduced `RuleSet` class for encapsulating reusable architecture rules, with standalone execution (`.check()`, `.verify()`), composition (`+`, `apply`), and metadata.
- Introduced `RuleSetBuilder` supporting all rule domains (`modules`, `classes`, `functions`, `properties`, `files`, `slices`, `layeredArchitecture`, `layered`, `layer`, `sourceSet`, `rule`, `noCycles`, `apply`).
- Added top-level `architectureRules { ... }` and `Konture.architectureRules { ... }` builder DSL.
- Added `apply(ruleSet)`, `apply(ruleDefinition)`, `noCycles()`, and sourceSet overloads to `KontureContext`.
- Added unit tests in `RuleSetTest.kt` covering creation, execution, custom extension functions, error aggregation, composition, and standalone verification.
- Updated binary compatibility ABI dump (`library.api`).

## Verification
- [x] `./gradlew -q spotlessApply`
- [x] `./gradlew -q :core:test :library:test :plugin-gradle:test`
- [x] `./gradlew -q checkKotlinAbi`
- [x] `python3 script/add_front_matter.py --validate`