### PR TITLE
feat(issue-75): Unified Package & Module Pattern Matchers (under(...))

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1410,3 +1410,17 @@ public final class io/github/baole/konture/core/report/sarif/SarifTool$Companion
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/github/baole/konture/modules {
+	public static final field INSTANCE Lio/github/baole/konture/modules;
+	public final fun under (Ljava/lang/String;)Ljava/lang/String;
+	public final fun under (Ljava/util/List;)Ljava/util/List;
+	public final fun under ([Ljava/lang/String;)Ljava/util/List;
+}
+
+public final class io/github/baole/konture/packages {
+	public static final field INSTANCE Lio/github/baole/konture/packages;
+	public final fun under (Ljava/lang/String;)Ljava/lang/String;
+	public final fun under (Ljava/util/List;)Ljava/util/List;
+	public final fun under ([Ljava/lang/String;)Ljava/util/List;
+}
+

--- a/core/src/main/kotlin/io/github/baole/konture/Matchers.kt
+++ b/core/src/main/kotlin/io/github/baole/konture/Matchers.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc (@baole)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture
+
+/**
+ * Unified pattern matchers for Gradle module paths.
+ */
+public object modules {
+    /**
+     * Converts a module base path into a recursive glob pattern matching all submodules under it.
+     *
+     * Example:
+     * ```kotlin
+     * modules.under(":feature") // produces ":feature:**" which matches ":feature:checkout", ":feature:profile"
+     * ```
+     *
+     * @param path The base module path (e.g., `":feature"`, `"feature"`, or `":"`).
+     * @return The normalized module glob pattern.
+     */
+    public fun under(path: String): String {
+        val trimmed = path.trim()
+        val normalized =
+            when {
+                trimmed.isEmpty() || trimmed == ":" -> ":**"
+                trimmed.endsWith(":**") -> trimmed
+                trimmed.endsWith(":") -> "$trimmed**"
+                trimmed.startsWith(":") -> "$trimmed:**"
+                else -> ":$trimmed:**"
+            }
+        return normalized
+    }
+
+    /**
+     * Converts multiple module base paths into recursive glob patterns matching all submodules under them.
+     */
+    public fun under(vararg paths: String): List<String> = paths.map { under(it) }
+
+    /**
+     * Converts a list of module base paths into recursive glob patterns matching all submodules under them.
+     */
+    public fun under(paths: List<String>): List<String> = paths.map { under(it) }
+}
+
+/**
+ * Unified pattern matchers for package names.
+ */
+public object packages {
+    /**
+     * Converts a base package name into a recursive package pattern matching the package and all its subpackages.
+     *
+     * Example:
+     * ```kotlin
+     * packages.under("com.acme.domain") // produces "com.acme.domain.." which matches "com.acme.domain.model", etc.
+     * ```
+     *
+     * @param packageName The base package name (e.g., `"com.acme.domain"`).
+     * @return The normalized package pattern.
+     */
+    public fun under(packageName: String): String {
+        val trimmed = packageName.trim()
+        val normalized =
+            when {
+                trimmed.isEmpty() || trimmed == ".." -> ".."
+                trimmed.endsWith("..") -> trimmed
+                trimmed.endsWith(".") -> "${trimmed}."
+                else -> "$trimmed.."
+            }
+        return normalized
+    }
+
+    /**
+     * Converts multiple base package names into recursive package patterns matching the packages and all their subpackages.
+     */
+    public fun under(vararg packageNames: String): List<String> = packageNames.map { under(it) }
+
+    /**
+     * Converts a list of base package names into recursive package patterns matching the packages and all their subpackages.
+     */
+    public fun under(packageNames: List<String>): List<String> = packageNames.map { under(it) }
+}
+
+/**
+ * Typealias for [modules] matching PascalCase Kotlin naming conventions.
+ */
+public typealias Modules = modules
+
+/**
+ * Typealias for [packages] matching PascalCase Kotlin naming conventions.
+ */
+public typealias Packages = packages

--- a/core/src/main/kotlin/io/github/baole/konture/Matchers.kt
+++ b/core/src/main/kotlin/io/github/baole/konture/Matchers.kt
@@ -9,6 +9,7 @@ package io.github.baole.konture
 /**
  * Unified pattern matchers for Gradle module paths.
  */
+@Suppress("ClassName", "ClassNaming")
 public object modules {
     /**
      * Converts a module base path into a recursive glob pattern matching all submodules under it.
@@ -23,15 +24,15 @@ public object modules {
      */
     public fun under(path: String): String {
         val trimmed = path.trim()
-        val normalized =
-            when {
-                trimmed.isEmpty() || trimmed == ":" -> ":**"
-                trimmed.endsWith(":**") -> trimmed
-                trimmed.endsWith(":") -> "$trimmed**"
-                trimmed.startsWith(":") -> "$trimmed:**"
-                else -> ":$trimmed:**"
-            }
-        return normalized
+        if (trimmed.isEmpty() || trimmed == ":" || trimmed == ":**" || trimmed == "**") {
+            return ":**"
+        }
+        val withColon = if (trimmed.startsWith(":")) trimmed else ":$trimmed"
+        return when {
+            withColon.endsWith(":**") -> withColon
+            withColon.endsWith(":") -> "$withColon**"
+            else -> "$withColon:**"
+        }
     }
 
     /**
@@ -48,6 +49,7 @@ public object modules {
 /**
  * Unified pattern matchers for package names.
  */
+@Suppress("ClassName", "ClassNaming")
 public object packages {
     /**
      * Converts a base package name into a recursive package pattern matching the package and all its subpackages.
@@ -62,14 +64,12 @@ public object packages {
      */
     public fun under(packageName: String): String {
         val trimmed = packageName.trim()
-        val normalized =
-            when {
-                trimmed.isEmpty() || trimmed == ".." -> ".."
-                trimmed.endsWith("..") -> trimmed
-                trimmed.endsWith(".") -> "${trimmed}."
-                else -> "$trimmed.."
-            }
-        return normalized
+        return when {
+            trimmed.isEmpty() || trimmed == ".." -> ".."
+            trimmed.endsWith("..") -> trimmed
+            trimmed.endsWith(".") -> "$trimmed."
+            else -> "$trimmed.."
+        }
     }
 
     /**

--- a/core/src/test/kotlin/io/github/baole/konture/core/MatchersTest.kt
+++ b/core/src/test/kotlin/io/github/baole/konture/core/MatchersTest.kt
@@ -19,12 +19,16 @@ class MatchersTest {
         assertEquals(":feature:**", modules.under(":feature"))
         assertEquals(":feature:**", modules.under("feature"))
         assertEquals(":feature:**", modules.under(":feature:"))
+        assertEquals(":feature:**", modules.under("feature:"))
         assertEquals(":feature:**", modules.under(":feature:**"))
+        assertEquals(":feature:**", modules.under("feature:**"))
         assertEquals(":feature:checkout:**", modules.under(":feature:checkout"))
         assertEquals(":feature:checkout:**", modules.under("feature:checkout"))
         assertEquals(":**", modules.under(":"))
         assertEquals(":**", modules.under(""))
         assertEquals(":**", modules.under("   "))
+        assertEquals(":**", modules.under("**"))
+        assertEquals(":**", modules.under(":**"))
     }
 
     @Test

--- a/core/src/test/kotlin/io/github/baole/konture/core/MatchersTest.kt
+++ b/core/src/test/kotlin/io/github/baole/konture/core/MatchersTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc (@baole)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture.core
+
+import io.github.baole.konture.Modules
+import io.github.baole.konture.Packages
+import io.github.baole.konture.modules
+import io.github.baole.konture.packages
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MatchersTest {
+    @Test
+    fun `modules under generates correct recursive glob patterns`() {
+        assertEquals(":feature:**", modules.under(":feature"))
+        assertEquals(":feature:**", modules.under("feature"))
+        assertEquals(":feature:**", modules.under(":feature:"))
+        assertEquals(":feature:**", modules.under(":feature:**"))
+        assertEquals(":feature:checkout:**", modules.under(":feature:checkout"))
+        assertEquals(":feature:checkout:**", modules.under("feature:checkout"))
+        assertEquals(":**", modules.under(":"))
+        assertEquals(":**", modules.under(""))
+        assertEquals(":**", modules.under("   "))
+    }
+
+    @Test
+    fun `modules under supports vararg and list overloads`() {
+        val expected = listOf(":feature:**", ":core:**")
+        assertEquals(expected, modules.under(":feature", ":core"))
+        assertEquals(expected, modules.under(listOf(":feature", ":core")))
+    }
+
+    @Test
+    fun `packages under generates correct recursive package patterns`() {
+        assertEquals("com.acme.domain..", packages.under("com.acme.domain"))
+        assertEquals("com.acme.domain..", packages.under("com.acme.domain."))
+        assertEquals("com.acme.domain..", packages.under("com.acme.domain.."))
+        assertEquals("com.acme..", packages.under("com.acme"))
+        assertEquals("domain..", packages.under("domain"))
+        assertEquals("..", packages.under(""))
+        assertEquals("..", packages.under("   "))
+        assertEquals("..", packages.under(".."))
+    }
+
+    @Test
+    fun `packages under supports vararg and list overloads`() {
+        val expected = listOf("com.acme.domain..", "com.acme.feature..")
+        assertEquals(expected, packages.under("com.acme.domain", "com.acme.feature"))
+        assertEquals(expected, packages.under(listOf("com.acme.domain", "com.acme.feature")))
+    }
+
+    @Test
+    fun `PascalCase aliases work identically to lowercase objects`() {
+        assertEquals(modules.under(":feature"), Modules.under(":feature"))
+        assertEquals(packages.under("com.acme"), Packages.under("com.acme"))
+    }
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -200,6 +200,34 @@ Konture.modules {
 
 ```
 
+## 🎯 Unified Pattern Matchers (`under(...)`)
+
+Simplify matching syntax for packages and Gradle modules using unified `under(...)` helpers, avoiding the need to remember distinct wildcard syntax (`..` vs `**`):
+
+```kotlin
+// Matches :feature:checkout, :feature:profile, etc.
+modules.under(":feature")
+
+// Matches com.acme.domain, com.acme.domain.model, com.acme.domain.service.impl, etc.
+packages.under("com.acme.domain")
+
+// Usage in architecture layer definitions:
+architecture {
+    layer("feature") {
+        selector {
+            modules(modules.under(":feature"))
+            packages(packages.under("com.acme.feature"))
+        }
+        mayDependOn("core")
+    }
+}
+
+// Usage in declarative rules:
+Konture.classes {
+    that().resideInAPackage(packages.under("com.acme.feature"))
+        .should().notDependOnPackages(packages.under("com.acme.legacy"))
+}
+```
 
 Typed function and property rules compare the resolved raw declared type. For example, `List::class` matches `List<String>`, while explicit imports and import aliases resolve to their fully qualified types. Ambiguous references, generic arguments, nullability, type aliases, and type parameters still require the existing string or custom assertion APIs.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -200,6 +200,8 @@ Konture.modules {
 
 ```
 
+Typed function and property rules compare the resolved raw declared type. For example, `List::class` matches `List<String>`, while explicit imports and import aliases resolve to their fully qualified types. Ambiguous references, generic arguments, nullability, type aliases, and type parameters still require the existing string or custom assertion APIs.
+
 ## 🎯 Unified Pattern Matchers (`under(...)`)
 
 Simplify matching syntax for packages and Gradle modules using unified `under(...)` helpers, avoiding the need to remember distinct wildcard syntax (`..` vs `**`):
@@ -228,8 +230,6 @@ Konture.classes {
         .should().notDependOnPackages(packages.under("com.acme.legacy"))
 }
 ```
-
-Typed function and property rules compare the resolved raw declared type. For example, `List::class` matches `List<String>`, while explicit imports and import aliases resolve to their fully qualified types. Ambiguous references, generic arguments, nullability, type aliases, and type parameters still require the existing string or custom assertion APIs.
 
 Because Konture compiled layouts run as standard unit tests on the JVM, executing them is fast and seamless. Run the tests using your build system or trigger them directly from your IDE gutter.
 

--- a/library/src/test/kotlin/io/github/baole/konture/UnifiedPatternMatchersTest.kt
+++ b/library/src/test/kotlin/io/github/baole/konture/UnifiedPatternMatchersTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc (@baole)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class UnifiedPatternMatchersTest {
+    private fun mockClass(
+        fqName: String,
+        isInterface: Boolean = false,
+        dependencies: List<String> = emptyList(),
+    ): ClassDeclaration {
+        val simpleName = fqName.substringAfterLast('.')
+        val pkg = if (fqName.contains('.')) fqName.substringBeforeLast('.') else ""
+        return ClassDeclaration(
+            name = simpleName,
+            fqName = fqName,
+            packageName = pkg,
+            isInterface = isInterface,
+            isAbstract = false,
+            isEnum = false,
+            annotations = emptyList(),
+            imports = dependencies.map { "import $it.*" },
+            referencedTypes = dependencies.toSet(),
+            filePath = "/src/$simpleName.kt",
+            visibility = Visibility.PUBLIC,
+            modifiers = emptySet(),
+        )
+    }
+
+    private fun mockModule(
+        path: String,
+        dependencies: List<String> = emptyList(),
+        files: List<FileDeclaration> = emptyList(),
+    ): Module {
+        return Module(
+            buildId = "root",
+            path = path,
+            projectDir = path.replace(':', '/'),
+            appliedPlugins = listOf("org.jetbrains.kotlin.jvm"),
+            sourceSets = emptyList(),
+            dependencies =
+                dependencies.map {
+                    Dependency(configuration = "implementation", targetBuildId = "root", targetPath = it)
+                },
+            files = files,
+        )
+    }
+
+    private fun mockFile(
+        name: String,
+        packageName: String,
+        classes: List<ClassDeclaration> = emptyList(),
+    ): FileDeclaration {
+        return FileDeclaration(
+            name = name,
+            packageName = packageName,
+            imports = emptyList(),
+            classes = classes,
+            filePath = "/src/$packageName/$name",
+        )
+    }
+
+    @Test
+    fun `modules under filters module selectors correctly`() {
+        val modFeatureCheckout = mockModule(":feature:checkout")
+        val modFeatureProfile = mockModule(":feature:profile")
+        val modCore = mockModule(":core:database")
+
+        val selector: ModuleSelector = KontureModuleScope(listOf(modFeatureCheckout, modFeatureProfile, modCore))
+
+        val featureModules = selector.withName(modules.under(":feature"))
+        assertEquals(2, featureModules.modules.size)
+        assertTrue(featureModules.modules.any { it.path == ":feature:checkout" })
+        assertTrue(featureModules.modules.any { it.path == ":feature:profile" })
+
+        val coreModules = selector.withName(Modules.under(":core"))
+        assertEquals(1, coreModules.modules.size)
+        assertEquals(":core:database", coreModules.modules.first().path)
+    }
+
+    @Test
+    fun `packages under filters class selectors correctly`() {
+        val classDomainModel = mockClass("com.acme.domain.model.User")
+        val classDomainRepo = mockClass("com.acme.domain.repository.UserRepository", isInterface = true)
+        val classFeatureUI = mockClass("com.acme.feature.checkout.CheckoutScreen")
+
+        val selector: ClassSelector = KontureScope(listOf(classDomainModel, classDomainRepo, classFeatureUI))
+
+        val domainClasses = selector.inPackage(packages.under("com.acme.domain"))
+        assertEquals(2, domainClasses.classes.size)
+        assertTrue(domainClasses.classes.any { it.fqName == "com.acme.domain.model.User" })
+        assertTrue(domainClasses.classes.any { it.fqName == "com.acme.domain.repository.UserRepository" })
+
+        val featureClasses = selector.inPackage(Packages.under("com.acme.feature"))
+        assertEquals(1, featureClasses.classes.size)
+        assertEquals("com.acme.feature.checkout.CheckoutScreen", featureClasses.classes.first().fqName)
+    }
+
+    @Test
+    fun `modules under and packages under integrate with LayerSelectorDsl`() {
+        val policy = ArchitectureLayerPolicy("feature")
+        policy.selector {
+            modules(modules.under(":feature"))
+            packages(packages.under("com.acme.feature"))
+        }
+
+        val snapshot = policy.selectorSnapshot()
+        assertEquals(listOf(":feature:**"), snapshot.modulePatterns)
+        assertEquals(listOf("com.acme.feature.."), snapshot.packagePatterns)
+    }
+
+    @Test
+    fun `modules and packages under multi-argument overloads with LayerSelectorDsl`() {
+        val policy = ArchitectureLayerPolicy("core_and_feature")
+        policy.selector {
+            modules(modules.under(":core", ":feature"))
+            packages(packages.under("com.acme.core", "com.acme.feature"))
+        }
+
+        val snapshot = policy.selectorSnapshot()
+        assertEquals(listOf(":core:**", ":feature:**"), snapshot.modulePatterns)
+        assertEquals(listOf("com.acme.core..", "com.acme.feature.."), snapshot.packagePatterns)
+    }
+
+    @Test
+    fun `file selector inPackage supports packages under`() {
+        val fileDomain = mockFile("User.kt", "com.acme.domain.model")
+        val fileFeature = mockFile("Checkout.kt", "com.acme.feature.checkout")
+
+        val selector: FileSelector = KontureFileScope(listOf(fileDomain, fileFeature))
+        val domainFiles = selector.inPackage(packages.under("com.acme.domain"))
+
+        assertEquals(1, domainFiles.files.size)
+        assertEquals("User.kt", domainFiles.files.first().name)
+    }
+}


### PR DESCRIPTION
## Summary of Changes
- Implemented `modules.under(...)` and `packages.under(...)` unified pattern matchers in `core` module (`io.github.baole.konture`) to eliminate the need to memorize distinct wildcard syntaxes (`..` vs `**`).
- Provided `Modules` and `Packages` PascalCase typealiases for Kotlin style flexibility.
- Maintained complete backward compatibility for standard glob and package matching syntax.
- Added comprehensive unit tests in `:core:test` and DSL integration tests in `:library:test`.
- Updated binary compatibility ABI dumps and usage documentation.

Closes #75

## Verification Results
- `./gradlew -q assemble` (passed)
- `./gradlew -q :core:test` (passed)
- `./gradlew -q :library:test` (passed)
- `./gradlew -q checkKotlinAbi` (passed)
- `./gradlew -q spotlessApply` (passed)
- `python3 script/add_front_matter.py --validate` (passed)