### PR TITLE
feat(cache): Persistent disk caching & rule-level analysis cache (#77)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ build/
 .kotlin/
 **/.kotlin/
 
+# Konture
+.konture/
+
 # IntelliJ IDEA
 .idea/
 *.iml

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -135,6 +135,8 @@ public final class io/github/baole/konture/core/ExclusionsModel$Companion {
 
 public final class io/github/baole/konture/core/KontureConstants {
 	public static final field DEFAULT_BASELINE_FILENAME Ljava/lang/String;
+	public static final field DEFAULT_CACHE_DIR Ljava/lang/String;
+	public static final field DEFAULT_CACHE_ENABLED Z
 	public static final field DEFAULT_FAIL_ON_RESOLVED_VIOLATIONS Z
 	public static final field DEFAULT_HTML_REPORT_PATH Ljava/lang/String;
 	public static final field DEFAULT_INCREMENTAL_ENABLED Z
@@ -146,6 +148,9 @@ public final class io/github/baole/konture/core/KontureConstants {
 	public static final field PROPERTY_BASELINE_DIR Ljava/lang/String;
 	public static final field PROPERTY_BASELINE_GENERATE Ljava/lang/String;
 	public static final field PROPERTY_BASELINE_PATH Ljava/lang/String;
+	public static final field PROPERTY_CACHE_DIR Ljava/lang/String;
+	public static final field PROPERTY_CACHE_ENABLED Ljava/lang/String;
+	public static final field PROPERTY_CACHE_FINGERPRINT Ljava/lang/String;
 	public static final field PROPERTY_FAIL_ON_RESOLVED_VIOLATIONS Ljava/lang/String;
 	public static final field PROPERTY_FAIL_ON_SEVERITY Ljava/lang/String;
 	public static final field PROPERTY_INCREMENTAL_ENABLED Ljava/lang/String;

--- a/core/src/main/kotlin/io/github/baole/konture/core/KontureConstants.kt
+++ b/core/src/main/kotlin/io/github/baole/konture/core/KontureConstants.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -120,4 +120,31 @@ public object KontureConstants {
      * Default value for incremental AST analysis.
      */
     public const val DEFAULT_INCREMENTAL_ENABLED: Boolean = true
+
+    /**
+     * System property key used to enable/disable persistent disk caching of analysis results.
+     */
+    public const val PROPERTY_CACHE_ENABLED: String = "konture.cache.enabled"
+
+    /**
+     * System property key used to override the persistent cache directory.
+     */
+    public const val PROPERTY_CACHE_DIR: String = "konture.cache.dir"
+
+    /**
+     * System property key used to override the persistent cache fingerprint.
+     * The fingerprint namespaces the disk cache so rule or configuration changes
+     * automatically invalidate previously stored entries.
+     */
+    public const val PROPERTY_CACHE_FINGERPRINT: String = "konture.cache.fingerprint"
+
+    /**
+     * Default value for persistent disk caching.
+     */
+    public const val DEFAULT_CACHE_ENABLED: Boolean = false
+
+    /**
+     * Default persistent cache directory (resolved against the current working directory).
+     */
+    public const val DEFAULT_CACHE_DIR: String = ".konture/cache"
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,8 +34,37 @@ konture {
 
     // Set translation language for violation messages (default is "en")
     language("fr")
+
+    // Tune analysis performance and persistent caching
+    analysis {
+        incremental = true   // incremental AST analysis (default: true)
+        cache = true         // persistent disk cache in .konture/cache (default: false)
+        // cacheDir = "custom/cache/path"   // optional override
+    }
 }
 ```
+
+### ⚡ Persistent Analysis Cache & Gradle Build Cache
+
+When `analysis { cache = true }` is enabled, parsed AST snapshots are persisted to a disk
+cache (`.konture/cache/<module-path>/<fingerprint>/ast/v1/` by default) and reused across
+test executions, so unchanged Kotlin files skip re-parsing entirely — even between separate
+JVM runs.
+
+- **Source changes invalidate automatically**: cache entries are keyed by the SHA-256 content
+  hash of each analyzed file, so editing a file always re-parses it.
+- **Rule/config changes invalidate automatically**: the cache directory is namespaced by a
+  fingerprint derived from the effective `analysis { }` configuration (and the rest of the
+  `konture { }` block). Changing any rule-affecting setting selects a fresh cache namespace,
+  leaving stale entries unused.
+- **Gradle build cache integration**: the cache directory is declared as an output of each
+  test task, so Gradle's up-to-date checks and build cache can snapshot, restore, and skip
+  evaluation entirely for unchanged inputs.
+- **Library-level control**: the same flags are available programmatically via
+  `Konture.cacheEnabled`, `Konture.cacheDir`, and `Konture.cacheFingerprint`, or via the
+  system properties `konture.cache.enabled`, `konture.cache.dir`,
+  `konture.cache.fingerprint`, and `konture.incremental.enabled`. Corruption is never fatal:
+  unreadable cache entries are treated as misses and re-parsed.
 
 ### Automatic test inputs
 
@@ -108,6 +137,9 @@ Declare your plugin configurations inside the `<configuration>` block of the `ko
 | **`outputFormat`** | `"HUMAN"` | Configures output formatting for architectural rule violations.<br>• Supported formats: `"HUMAN"` (default multi-line console output), `"PROBLEM_MATCHER"` (single-line IDE/CI problem matcher format `path:line:col: Konture [ruleId]: message`), `"HTML"` (standalone HTML report), `"JSON"` (schema-validated JSON report), `"SARIF"` (OASIS SARIF v2.1.0 standard for GitHub Code Scanning / SonarQube). Can also be overridden via system property `-Dkonture.output.format=json` or programmatically via `Konture.outputFormat`. |
 | **`reportPath`** | `"build/reports/konture/konture-report.html"` | Configures destination file path for standalone output report files.<br>• Can be overridden via system property `-Dkonture.report.path=build/reports/custom-report.html` or programmatically via `Konture.reportPath`. Format-specific paths can also be set via `konture.report.html.path`, `konture.report.json.path`, or `konture.report.sarif.path`. |
 | **`incremental`** | `true` | Enables incremental AST analysis and SHA-256 source content hashing to skip re-parsing unchanged Kotlin files.<br>• Can be overridden via system property `-Dkonture.incremental.enabled=false` or programmatically via `Konture.incremental`. |
+| **`analysis.incremental`** | `true` | Gradle DSL equivalent of `incremental` inside the `analysis { }` block. |
+| **`analysis.cache`** | `false` | Enables the persistent disk analysis cache (`.konture/cache`) so unchanged Kotlin files skip re-parsing across test executions.<br>• The cache directory is declared as a test-task output for Gradle build cache / up-to-date checks.<br>• Can be overridden via system property `-Dkonture.cache.enabled=false` or programmatically via `Konture.cacheEnabled`. |
+| **`analysis.cacheDir`** | `""` (auto) | Optional override of the persistent cache directory. The plugin always appends the module path to the resolved value, so the effective directory is `<cacheDir>/<module-path>/` (default `<rootProject>/.konture/cache/<module-path>/`) and consumer test tasks never share or overwrite the same directory. |
 
 ---
 

--- a/library/api/library.api
+++ b/library/api/library.api
@@ -1,4 +1,5 @@
 public final class io/github/baole/konture/AnnotationArgumentDeclaration {
+	public static final field Companion Lio/github/baole/konture/AnnotationArgumentDeclaration$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
@@ -11,7 +12,23 @@ public final class io/github/baole/konture/AnnotationArgumentDeclaration {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class io/github/baole/konture/AnnotationArgumentDeclaration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/baole/konture/AnnotationArgumentDeclaration$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/baole/konture/AnnotationArgumentDeclaration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/baole/konture/AnnotationArgumentDeclaration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/baole/konture/AnnotationArgumentDeclaration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/baole/konture/AnnotationDeclaration {
+	public static final field Companion Lio/github/baole/konture/AnnotationDeclaration$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -25,6 +42,21 @@ public final class io/github/baole/konture/AnnotationDeclaration {
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/baole/konture/AnnotationDeclaration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/baole/konture/AnnotationDeclaration$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/baole/konture/AnnotationDeclaration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/baole/konture/AnnotationDeclaration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/baole/konture/AnnotationDeclaration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/github/baole/konture/ArchitectureKt {
@@ -67,6 +99,7 @@ public final class io/github/baole/konture/ArchitectureSourceSetPolicy {
 }
 
 public final class io/github/baole/konture/ClassDeclaration {
+	public static final field Companion Lio/github/baole/konture/ClassDeclaration$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/List;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Lio/github/baole/konture/Visibility;Ljava/util/Set;Ljava/util/List;Lio/github/baole/konture/ConstructorDeclaration;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/baole/konture/ClassDeclaration;Ljava/lang/String;Ljava/util/Map;ZI)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/List;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Lio/github/baole/konture/Visibility;Ljava/util/Set;Ljava/util/List;Lio/github/baole/konture/ConstructorDeclaration;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/baole/konture/ClassDeclaration;Ljava/lang/String;Ljava/util/Map;ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -116,6 +149,21 @@ public final class io/github/baole/konture/ClassDeclaration {
 	public final fun isEnum ()Z
 	public final fun isInterface ()Z
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/baole/konture/ClassDeclaration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/baole/konture/ClassDeclaration$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/baole/konture/ClassDeclaration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/baole/konture/ClassDeclaration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/baole/konture/ClassDeclaration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/github/baole/konture/ClassDeclarationShouldContext {
@@ -1460,6 +1508,7 @@ public final class io/github/baole/konture/ClassesThatStructureFilter$DefaultImp
 }
 
 public final class io/github/baole/konture/ConstructorDeclaration {
+	public static final field Companion Lio/github/baole/konture/ConstructorDeclaration$Companion;
 	public fun <init> (Lio/github/baole/konture/Visibility;Ljava/util/List;Ljava/util/List;)V
 	public final fun component1 ()Lio/github/baole/konture/Visibility;
 	public final fun component2 ()Ljava/util/List;
@@ -1472,6 +1521,21 @@ public final class io/github/baole/konture/ConstructorDeclaration {
 	public final fun getVisibility ()Lio/github/baole/konture/Visibility;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/baole/konture/ConstructorDeclaration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/baole/konture/ConstructorDeclaration$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/baole/konture/ConstructorDeclaration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/baole/konture/ConstructorDeclaration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/baole/konture/ConstructorDeclaration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/github/baole/konture/Dependency {
@@ -1563,6 +1627,7 @@ public final class io/github/baole/konture/ExtensionsKt {
 }
 
 public final class io/github/baole/konture/FileDeclaration {
+	public static final field Companion Lio/github/baole/konture/FileDeclaration$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -1594,6 +1659,21 @@ public final class io/github/baole/konture/FileDeclaration {
 	public final fun getUsages ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/baole/konture/FileDeclaration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/baole/konture/FileDeclaration$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/baole/konture/FileDeclaration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/baole/konture/FileDeclaration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/baole/konture/FileDeclaration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/github/baole/konture/FileDeclarationContext {
@@ -2376,6 +2456,7 @@ public final class io/github/baole/konture/FunctionAssertionScope {
 }
 
 public final class io/github/baole/konture/FunctionDeclaration {
+	public static final field Companion Lio/github/baole/konture/FunctionDeclaration$Companion;
 	public fun <init> (Ljava/lang/String;Lio/github/baole/konture/Visibility;Ljava/util/Set;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ZIILjava/lang/String;ILjava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Lio/github/baole/konture/Visibility;Ljava/util/Set;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ZIILjava/lang/String;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -2409,6 +2490,21 @@ public final class io/github/baole/konture/FunctionDeclaration {
 	public fun hashCode ()I
 	public final fun isExtension ()Z
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/baole/konture/FunctionDeclaration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/baole/konture/FunctionDeclaration$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/baole/konture/FunctionDeclaration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/baole/konture/FunctionDeclaration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/baole/konture/FunctionDeclaration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/github/baole/konture/FunctionDeclarationContext {
@@ -3383,6 +3479,8 @@ public final class io/github/baole/konture/HumanReadableViolationFormatter {
 
 public final class io/github/baole/konture/Konture {
 	public static final field DEFAULT_BASELINE_FILENAME Ljava/lang/String;
+	public static final field DEFAULT_CACHE_DIR Ljava/lang/String;
+	public static final field DEFAULT_CACHE_ENABLED Z
 	public static final field DEFAULT_FAIL_ON_RESOLVED_VIOLATIONS Z
 	public static final field DEFAULT_HTML_REPORT_PATH Ljava/lang/String;
 	public static final field DEFAULT_INCREMENTAL_ENABLED Z
@@ -3393,6 +3491,9 @@ public final class io/github/baole/konture/Konture {
 	public static final field PROPERTY_BASELINE_DIR Ljava/lang/String;
 	public static final field PROPERTY_BASELINE_GENERATE Ljava/lang/String;
 	public static final field PROPERTY_BASELINE_PATH Ljava/lang/String;
+	public static final field PROPERTY_CACHE_DIR Ljava/lang/String;
+	public static final field PROPERTY_CACHE_ENABLED Ljava/lang/String;
+	public static final field PROPERTY_CACHE_FINGERPRINT Ljava/lang/String;
 	public static final field PROPERTY_FAIL_ON_RESOLVED_VIOLATIONS Ljava/lang/String;
 	public static final field PROPERTY_FAIL_ON_SEVERITY Ljava/lang/String;
 	public static final field PROPERTY_INCREMENTAL_ENABLED Ljava/lang/String;
@@ -3405,6 +3506,9 @@ public final class io/github/baole/konture/Konture {
 	public static final field PROPERTY_REPORT_SARIF_PATH Ljava/lang/String;
 	public final fun checkRatchet ()V
 	public final fun getBaselinePath ()Ljava/lang/String;
+	public final fun getCacheDir ()Ljava/io/File;
+	public final fun getCacheEnabled ()Z
+	public final fun getCacheFingerprint ()Ljava/lang/String;
 	public final fun getFailOnResolvedViolations ()Z
 	public final fun getFailOnSeverity ()Lio/github/baole/konture/core/model/Severity;
 	public final fun getGenerateBaseline ()Z
@@ -3419,6 +3523,9 @@ public final class io/github/baole/konture/Konture {
 	public final fun getSarifReportPath ()Ljava/lang/String;
 	public final fun reset ()V
 	public final fun setBaselinePath (Ljava/lang/String;)V
+	public final fun setCacheDir (Ljava/io/File;)V
+	public final fun setCacheEnabled (Z)V
+	public final fun setCacheFingerprint (Ljava/lang/String;)V
 	public final fun setFailOnResolvedViolations (Z)V
 	public final fun setFailOnSeverity (Lio/github/baole/konture/core/model/Severity;)V
 	public final fun setGenerateBaseline (Z)V
@@ -3897,6 +4004,7 @@ public final class io/github/baole/konture/Modifier : java/lang/Enum {
 	public static final field ACTUAL Lio/github/baole/konture/Modifier;
 	public static final field COMPANION Lio/github/baole/konture/Modifier;
 	public static final field CONST Lio/github/baole/konture/Modifier;
+	public static final field Companion Lio/github/baole/konture/Modifier$Companion;
 	public static final field DATA Lio/github/baole/konture/Modifier;
 	public static final field EXPECT Lio/github/baole/konture/Modifier;
 	public static final field INFIX Lio/github/baole/konture/Modifier;
@@ -3913,6 +4021,10 @@ public final class io/github/baole/konture/Modifier : java/lang/Enum {
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lio/github/baole/konture/Modifier;
 	public static fun values ()[Lio/github/baole/konture/Modifier;
+}
+
+public final class io/github/baole/konture/Modifier$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/github/baole/konture/Module {
@@ -4546,6 +4658,7 @@ public final class io/github/baole/konture/OutputFormat : java/lang/Enum {
 }
 
 public final class io/github/baole/konture/ParameterDeclaration {
+	public static final field Companion Lio/github/baole/konture/ParameterDeclaration$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -4563,6 +4676,21 @@ public final class io/github/baole/konture/ParameterDeclaration {
 	public final fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/baole/konture/ParameterDeclaration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/baole/konture/ParameterDeclaration$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/baole/konture/ParameterDeclaration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/baole/konture/ParameterDeclaration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/baole/konture/ParameterDeclaration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/github/baole/konture/PlatformPackages {
@@ -5277,6 +5405,7 @@ public final class io/github/baole/konture/PropertyAssertionScope {
 }
 
 public final class io/github/baole/konture/PropertyDeclaration {
+	public static final field Companion Lio/github/baole/konture/PropertyDeclaration$Companion;
 	public fun <init> (Ljava/lang/String;Lio/github/baole/konture/Visibility;Ljava/util/Set;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Lio/github/baole/konture/Visibility;Ljava/util/Set;Ljava/lang/String;ZLjava/util/List;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -5307,6 +5436,21 @@ public final class io/github/baole/konture/PropertyDeclaration {
 	public final fun isVal ()Z
 	public final fun isVar ()Z
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/baole/konture/PropertyDeclaration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/baole/konture/PropertyDeclaration$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/baole/konture/PropertyDeclaration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/baole/konture/PropertyDeclaration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/baole/konture/PropertyDeclaration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/github/baole/konture/PropertyDeclarationContext {
@@ -5382,12 +5526,17 @@ public final class io/github/baole/konture/PropertySelectorShould {
 }
 
 public final class io/github/baole/konture/ResolutionConfidence : java/lang/Enum {
+	public static final field Companion Lio/github/baole/konture/ResolutionConfidence$Companion;
 	public static final field POSSIBLE Lio/github/baole/konture/ResolutionConfidence;
 	public static final field RESOLVED Lio/github/baole/konture/ResolutionConfidence;
 	public static final field UNRESOLVED Lio/github/baole/konture/ResolutionConfidence;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lio/github/baole/konture/ResolutionConfidence;
 	public static fun values ()[Lio/github/baole/konture/ResolutionConfidence;
+}
+
+public final class io/github/baole/konture/ResolutionConfidence$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/github/baole/konture/RuleBuilder {
@@ -5750,6 +5899,7 @@ public final class io/github/baole/konture/SourceSet {
 }
 
 public final class io/github/baole/konture/SourceSetId {
+	public static final field Companion Lio/github/baole/konture/SourceSetId$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/github/baole/konture/SourceSetKind;Lio/github/baole/konture/SourceSetRole;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
@@ -5766,6 +5916,21 @@ public final class io/github/baole/konture/SourceSetId {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class io/github/baole/konture/SourceSetId$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/baole/konture/SourceSetId$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/baole/konture/SourceSetId;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/baole/konture/SourceSetId;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/baole/konture/SourceSetId$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/baole/konture/SourceSetKind : java/lang/Enum {
 	public static final field ANDROID Lio/github/baole/konture/SourceSetKind;
 	public static final field Companion Lio/github/baole/konture/SourceSetKind$Companion;
@@ -5779,6 +5944,7 @@ public final class io/github/baole/konture/SourceSetKind : java/lang/Enum {
 public final class io/github/baole/konture/SourceSetKind$Companion {
 	public final fun fromCoreKind (Lio/github/baole/konture/core/SourceSetKind;)Lio/github/baole/konture/SourceSetKind;
 	public final fun fromString (Ljava/lang/String;)Lio/github/baole/konture/SourceSetKind;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/github/baole/konture/SourceSetKt {
@@ -5786,11 +5952,16 @@ public final class io/github/baole/konture/SourceSetKt {
 }
 
 public final class io/github/baole/konture/SourceSetRole : java/lang/Enum {
+	public static final field Companion Lio/github/baole/konture/SourceSetRole$Companion;
 	public static final field PRODUCTION Lio/github/baole/konture/SourceSetRole;
 	public static final field TEST Lio/github/baole/konture/SourceSetRole;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lio/github/baole/konture/SourceSetRole;
 	public static fun values ()[Lio/github/baole/konture/SourceSetRole;
+}
+
+public final class io/github/baole/konture/SourceSetRole$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/github/baole/konture/SourceSetSelector {
@@ -5811,6 +5982,7 @@ public final class io/github/baole/konture/SourceSets {
 }
 
 public final class io/github/baole/konture/SourceUsage {
+	public static final field Companion Lio/github/baole/konture/SourceUsage$Companion;
 	public fun <init> (Lio/github/baole/konture/UsageKind;Ljava/lang/String;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZLio/github/baole/konture/ResolutionConfidence;IIII)V
 	public synthetic fun <init> (Lio/github/baole/konture/UsageKind;Ljava/lang/String;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZLio/github/baole/konture/ResolutionConfidence;IIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/github/baole/konture/UsageKind;
@@ -5852,6 +6024,21 @@ public final class io/github/baole/konture/SourceUsage {
 	public final fun getUnresolvedPossibleUsage ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/baole/konture/SourceUsage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/baole/konture/SourceUsage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/baole/konture/SourceUsage;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/baole/konture/SourceUsage;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/baole/konture/SourceUsage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/github/baole/konture/SourceUsageKt {
@@ -5962,12 +6149,18 @@ public final class io/github/baole/konture/TypeSafeOverloadsPropertiesKt {
 public final class io/github/baole/konture/UsageKind : java/lang/Enum {
 	public static final field CALL Lio/github/baole/konture/UsageKind;
 	public static final field CLASS_REFERENCE Lio/github/baole/konture/UsageKind;
+	public static final field Companion Lio/github/baole/konture/UsageKind$Companion;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lio/github/baole/konture/UsageKind;
 	public static fun values ()[Lio/github/baole/konture/UsageKind;
 }
 
+public final class io/github/baole/konture/UsageKind$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class io/github/baole/konture/Visibility : java/lang/Enum {
+	public static final field Companion Lio/github/baole/konture/Visibility$Companion;
 	public static final field INTERNAL Lio/github/baole/konture/Visibility;
 	public static final field PRIVATE Lio/github/baole/konture/Visibility;
 	public static final field PROTECTED Lio/github/baole/konture/Visibility;
@@ -5975,6 +6168,10 @@ public final class io/github/baole/konture/Visibility : java/lang/Enum {
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lio/github/baole/konture/Visibility;
 	public static fun values ()[Lio/github/baole/konture/Visibility;
+}
+
+public final class io/github/baole/konture/Visibility$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/github/baole/konture/impl/ProjectGraphLoaderKt {

--- a/library/src/main/kotlin/io/github/baole/konture/AnnotationArgumentDeclaration.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/AnnotationArgumentDeclaration.kt
@@ -1,12 +1,15 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.github.baole.konture
 
+import kotlinx.serialization.Serializable
+
 /** Represents an argument passed to a Kotlin annotation. */
+@Serializable
 public data class AnnotationArgumentDeclaration(
     /** Filter or assertion criteria for name. */
     public val name: String?,

--- a/library/src/main/kotlin/io/github/baole/konture/AnnotationDeclaration.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/AnnotationDeclaration.kt
@@ -1,10 +1,12 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.github.baole.konture
+
+import kotlinx.serialization.Serializable
 
 /**
  * Represents a parsed Kotlin annotation declared on a class.
@@ -13,6 +15,7 @@ package io.github.baole.konture
  * @property fqName The fully qualified name of the annotation if resolvable, or its simple name (e.g., `com.acme.annotations.UseCase`).
  * @property arguments List of arguments declared on the annotation.
  */
+@Serializable
 public data class AnnotationDeclaration(
     /** Filter or assertion criteria for name. */
     public val name: String,

--- a/library/src/main/kotlin/io/github/baole/konture/ClassDeclaration.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/ClassDeclaration.kt
@@ -1,10 +1,12 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.github.baole.konture
+
+import kotlinx.serialization.Serializable
 
 /**
  * Represents a parsed Kotlin class, interface, or object declaration.
@@ -21,6 +23,7 @@ package io.github.baole.konture
  * @property referencedTypes Set of simple types referenced/accessed in this class body (used for dependency inference).
  * @property filePath The absolute path of the file containing this class.
  */
+@Serializable
 public data class ClassDeclaration(
     /** Filter or assertion criteria for name. */
     public val name: String,

--- a/library/src/main/kotlin/io/github/baole/konture/ConstructorDeclaration.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/ConstructorDeclaration.kt
@@ -1,12 +1,15 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.github.baole.konture
 
+import kotlinx.serialization.Serializable
+
 /** Represents a constructor declaration of a Kotlin class. */
+@Serializable
 public data class ConstructorDeclaration(
     /** Filter or assertion criteria for visibility. */
     public val visibility: Visibility,

--- a/library/src/main/kotlin/io/github/baole/konture/FileDeclaration.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/FileDeclaration.kt
@@ -1,12 +1,15 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.github.baole.konture
 
+import kotlinx.serialization.Serializable
+
 /** Represents a source file declaration containing classes, functions, properties, and imports. */
+@Serializable
 public data class FileDeclaration(
     /** Filter or assertion criteria for name. */
     public val name: String,

--- a/library/src/main/kotlin/io/github/baole/konture/FunctionDeclaration.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/FunctionDeclaration.kt
@@ -1,10 +1,12 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.github.baole.konture
+
+import kotlinx.serialization.Serializable
 
 /**
  * Represents a parsed function declaration within a Kotlin source file.
@@ -23,6 +25,7 @@ package io.github.baole.konture
  * @property sourceLine 1-based source code line number.
  * @property receiverType Receiver type string if this is an extension function.
  */
+@Serializable
 public data class FunctionDeclaration(
     /** Filter or assertion criteria for name. */
     public val name: String,

--- a/library/src/main/kotlin/io/github/baole/konture/Konture.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/Konture.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,6 +10,7 @@ import io.github.baole.konture.core.KontureConstants
 import io.github.baole.konture.core.model.Severity
 import io.github.baole.konture.impl.BaselineManager
 import io.github.baole.konture.impl.KontureRuntimeStateProvider
+import java.io.File
 import java.util.Locale
 
 /**
@@ -63,6 +64,31 @@ public object Konture {
     public const val DEFAULT_INCREMENTAL_ENABLED: Boolean = KontureConstants.DEFAULT_INCREMENTAL_ENABLED
 
     /**
+     * System property key used to enable/disable persistent disk caching of analysis results.
+     */
+    public const val PROPERTY_CACHE_ENABLED: String = KontureConstants.PROPERTY_CACHE_ENABLED
+
+    /**
+     * System property key used to override the persistent cache directory.
+     */
+    public const val PROPERTY_CACHE_DIR: String = KontureConstants.PROPERTY_CACHE_DIR
+
+    /**
+     * System property key used to override the persistent cache fingerprint.
+     */
+    public const val PROPERTY_CACHE_FINGERPRINT: String = KontureConstants.PROPERTY_CACHE_FINGERPRINT
+
+    /**
+     * Default value for persistent disk caching.
+     */
+    public const val DEFAULT_CACHE_ENABLED: Boolean = KontureConstants.DEFAULT_CACHE_ENABLED
+
+    /**
+     * Default persistent cache directory.
+     */
+    public const val DEFAULT_CACHE_DIR: String = KontureConstants.DEFAULT_CACHE_DIR
+
+    /**
      * Whether incremental AST analysis and source hashing are enabled.
      * When enabled, unchanged Kotlin files are resolved from the AST cache without re-parsing.
      * Can be configured via system property "konture.incremental.enabled" or programmatically.
@@ -82,6 +108,65 @@ public object Konture {
                     incremental = value,
                     isIncrementalOverridden = true,
                 )
+        }
+
+    /**
+     * Whether persistent disk caching of analysis results is enabled.
+     * When enabled (requires [incremental] too), parsed AST snapshots are written to
+     * [cacheDir] and reused across JVM runs, so unchanged Kotlin files skip re-parsing
+     * entirely in later test executions.
+     * Can be configured via system property "konture.cache.enabled" or programmatically.
+     * Backed by ThreadLocal state; safe under parallel test execution.
+     */
+    public var cacheEnabled: Boolean
+        get() {
+            if (KontureRuntimeStateProvider.currentState.isCacheEnabledOverridden) {
+                return KontureRuntimeStateProvider.currentState.cacheEnabled
+            }
+            val systemProp = System.getProperty(PROPERTY_CACHE_ENABLED)
+            return systemProp?.toBoolean() ?: KontureRuntimeStateProvider.currentState.cacheEnabled
+        }
+        set(value) {
+            KontureRuntimeStateProvider.currentState =
+                KontureRuntimeStateProvider.currentState.copy(
+                    cacheEnabled = value,
+                    isCacheEnabledOverridden = true,
+                )
+        }
+
+    /**
+     * The base directory of the persistent analysis cache.
+     * Defaults to ".konture/cache" resolved against the current working directory.
+     * Can be configured via system property "konture.cache.dir" or programmatically.
+     * Backed by ThreadLocal state; safe under parallel test execution.
+     */
+    public var cacheDir: File
+        get() {
+            val systemProp = System.getProperty(PROPERTY_CACHE_DIR)
+            return systemProp?.let(::File) ?: KontureRuntimeStateProvider.currentState.cacheDir
+        }
+        set(value) {
+            KontureRuntimeStateProvider.currentState =
+                KontureRuntimeStateProvider.currentState.copy(cacheDir = value)
+        }
+
+    /**
+     * Optional fingerprint used to namespace the persistent analysis cache.
+     * Changing the fingerprint invalidates previously stored entries, which is the
+     * recommended way to invalidate the cache when rule definitions or analysis
+     * configuration change. The Gradle plugin computes this automatically from the
+     * effective `konture { analysis { } }` configuration.
+     * Can be configured via system property "konture.cache.fingerprint" or programmatically.
+     * Backed by ThreadLocal state; safe under parallel test execution.
+     */
+    public var cacheFingerprint: String
+        get() {
+            val systemProp = System.getProperty(PROPERTY_CACHE_FINGERPRINT)
+            return systemProp ?: KontureRuntimeStateProvider.currentState.cacheFingerprint
+        }
+        set(value) {
+            KontureRuntimeStateProvider.currentState =
+                KontureRuntimeStateProvider.currentState.copy(cacheFingerprint = value)
         }
 
     /**

--- a/library/src/main/kotlin/io/github/baole/konture/Modifier.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/Modifier.kt
@@ -1,14 +1,17 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.github.baole.konture
 
+import kotlinx.serialization.Serializable
+
 /**
  * Represents declaration modifiers in Kotlin source code (e.g. abstract, open, sealed, suspend, override).
  */
+@Serializable
 public enum class Modifier {
     /** Sealed class or interface modifier. */
     SEALED,

--- a/library/src/main/kotlin/io/github/baole/konture/ParameterDeclaration.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/ParameterDeclaration.kt
@@ -1,10 +1,12 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.github.baole.konture
+
+import kotlinx.serialization.Serializable
 
 /**
  * Represents a parameter in a function or constructor declaration.
@@ -15,6 +17,7 @@ package io.github.baole.konture
  * @property annotations List of annotations attached to this parameter.
  * @property resolvedType Fully qualified resolved type if available.
  */
+@Serializable
 public data class ParameterDeclaration(
     /** Filter or assertion criteria for name. */
     public val name: String,

--- a/library/src/main/kotlin/io/github/baole/konture/PropertyDeclaration.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/PropertyDeclaration.kt
@@ -1,10 +1,12 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.github.baole.konture
+
+import kotlinx.serialization.Serializable
 
 /**
  * Represents a property declaration within a Kotlin class or source file.
@@ -20,6 +22,7 @@ package io.github.baole.konture
  * @property resolvedType Fully qualified resolved type string if available.
  * @property sourceLine 1-based source code line number.
  */
+@Serializable
 public data class PropertyDeclaration(
     /** Filter or assertion criteria for name. */
     public val name: String,

--- a/library/src/main/kotlin/io/github/baole/konture/SourceSetSelection.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/SourceSetSelection.kt
@@ -1,14 +1,16 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.github.baole.konture
 
 import io.github.baole.konture.impl.PatternMatchers
+import kotlinx.serialization.Serializable
 
 /** A source set as exposed to architecture rules. */
+@Serializable
 public data class SourceSetId(
     /** Filter or assertion criteria for module path. */
     public val modulePath: String,
@@ -21,6 +23,7 @@ public data class SourceSetId(
 )
 
 /** Broad technology stack classification of a source set. */
+@Serializable
 public enum class SourceSetKind {
     /** JVM source set. */
     JVM,
@@ -60,6 +63,7 @@ public enum class SourceSetKind {
 }
 
 /** Indicates whether a source set contains production or test code. */
+@Serializable
 public enum class SourceSetRole {
     /** Production application or library source set. */
     PRODUCTION,

--- a/library/src/main/kotlin/io/github/baole/konture/SourceUsage.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/SourceUsage.kt
@@ -1,12 +1,15 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.github.baole.konture
 
+import kotlinx.serialization.Serializable
+
 /** Category of source code usage (e.g. function call or class reference). */
+@Serializable
 public enum class UsageKind {
     /** Direct function or constructor call. */
     CALL,
@@ -16,6 +19,7 @@ public enum class UsageKind {
 }
 
 /** Confidence level of a resolved symbol usage in source code analysis. */
+@Serializable
 public enum class ResolutionConfidence {
     /** Symbol usage was deterministically resolved. */
     RESOLVED,
@@ -28,6 +32,7 @@ public enum class ResolutionConfidence {
 }
 
 /** A resolved (or conservatively possible) Kotlin source usage. */
+@Serializable
 public data class SourceUsage(
     /** Filter or assertion criteria for kind. */
     public val kind: UsageKind,

--- a/library/src/main/kotlin/io/github/baole/konture/Visibility.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/Visibility.kt
@@ -1,14 +1,17 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.github.baole.konture
 
+import kotlinx.serialization.Serializable
+
 /**
  * Represents the visibility modifier of a Kotlin declaration (public, internal, protected, or private).
  */
+@Serializable
 public enum class Visibility {
     /**
      * Public visibility modifier.

--- a/library/src/main/kotlin/io/github/baole/konture/impl/KontureRuntimeState.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/impl/KontureRuntimeState.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,6 +13,7 @@ import io.github.baole.konture.core.KontureConstants
 import io.github.baole.konture.core.model.RuleMetadata
 import io.github.baole.konture.core.model.Severity
 import io.github.baole.konture.impl.report.ReportAccumulator
+import java.io.File
 import java.util.Locale
 
 @Suppress("LongParameterList")
@@ -38,6 +39,10 @@ internal class KontureRuntimeState(
     val isFailOnResolvedViolationsOverridden: Boolean = false,
     val incremental: Boolean = KontureConstants.DEFAULT_INCREMENTAL_ENABLED,
     val isIncrementalOverridden: Boolean = false,
+    val cacheEnabled: Boolean = KontureConstants.DEFAULT_CACHE_ENABLED,
+    val isCacheEnabledOverridden: Boolean = false,
+    val cacheDir: File = File(KontureConstants.DEFAULT_CACHE_DIR),
+    val cacheFingerprint: String = "",
 ) {
     val projectGraphLoader: ProjectGraphLoader = ProjectGraphLoader()
 
@@ -62,6 +67,10 @@ internal class KontureRuntimeState(
         isFailOnResolvedViolationsOverridden: Boolean = this.isFailOnResolvedViolationsOverridden,
         incremental: Boolean = this.incremental,
         isIncrementalOverridden: Boolean = this.isIncrementalOverridden,
+        cacheEnabled: Boolean = this.cacheEnabled,
+        isCacheEnabledOverridden: Boolean = this.isCacheEnabledOverridden,
+        cacheDir: File = this.cacheDir,
+        cacheFingerprint: String = this.cacheFingerprint,
     ): KontureRuntimeState {
         return KontureRuntimeState(
             baselinePath = baselinePath,
@@ -85,6 +94,10 @@ internal class KontureRuntimeState(
             isFailOnResolvedViolationsOverridden = isFailOnResolvedViolationsOverridden,
             incremental = incremental,
             isIncrementalOverridden = isIncrementalOverridden,
+            cacheEnabled = cacheEnabled,
+            isCacheEnabledOverridden = isCacheEnabledOverridden,
+            cacheDir = cacheDir,
+            cacheFingerprint = cacheFingerprint,
         )
     }
 }

--- a/library/src/main/kotlin/io/github/baole/konture/impl/cache/IncrementalAstCache.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/impl/cache/IncrementalAstCache.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -40,10 +40,14 @@ internal object IncrementalAstCache {
         val result = classFqNamesCache[hash]
         if (result != null) {
             classScanHitCount.incrementAndGet()
-        } else {
-            classScanMissCount.incrementAndGet()
+            return result
         }
-        return result
+        classScanMissCount.incrementAndGet()
+        val fromDisk = PersistentAstCacheStore.readClassFqNames(hash)
+        if (fromDisk != null) {
+            classFqNamesCache[hash] = fromDisk
+        }
+        return fromDisk
     }
 
     fun putClassFqNames(
@@ -51,16 +55,21 @@ internal object IncrementalAstCache {
         names: Set<String>,
     ) {
         classFqNamesCache[hash] = names
+        PersistentAstCacheStore.writeClassFqNames(hash, names)
     }
 
     fun getTypeAliases(hash: String): Map<String, TypeAliasDefinition>? {
         val result = typeAliasesCache[hash]
         if (result != null) {
             typeAliasScanHitCount.incrementAndGet()
-        } else {
-            typeAliasScanMissCount.incrementAndGet()
+            return result
         }
-        return result
+        typeAliasScanMissCount.incrementAndGet()
+        val fromDisk = PersistentAstCacheStore.readTypeAliases(hash)
+        if (fromDisk != null) {
+            typeAliasesCache[hash] = fromDisk
+        }
+        return fromDisk
     }
 
     fun putTypeAliases(
@@ -68,16 +77,21 @@ internal object IncrementalAstCache {
         aliases: Map<String, TypeAliasDefinition>,
     ) {
         typeAliasesCache[hash] = aliases
+        PersistentAstCacheStore.writeTypeAliases(hash, aliases)
     }
 
     fun getFileDeclaration(key: String): FileDeclaration? {
         val result = fileDeclarationCache[key]
         if (result != null) {
             parseHitCount.incrementAndGet()
-        } else {
-            parseMissCount.incrementAndGet()
+            return result
         }
-        return result
+        parseMissCount.incrementAndGet()
+        val fromDisk = PersistentAstCacheStore.readFileDeclaration(key)
+        if (fromDisk != null) {
+            fileDeclarationCache[key] = fromDisk
+        }
+        return fromDisk
     }
 
     fun putFileDeclaration(
@@ -85,6 +99,7 @@ internal object IncrementalAstCache {
         declaration: FileDeclaration,
     ) {
         fileDeclarationCache[key] = declaration
+        PersistentAstCacheStore.writeFileDeclaration(key, declaration)
     }
 
     fun clear() {
@@ -92,6 +107,7 @@ internal object IncrementalAstCache {
         typeAliasesCache.clear()
         fileDeclarationCache.clear()
         resetMetrics()
+        PersistentAstCacheStore.resetMetrics()
     }
 
     fun resetMetrics() {
@@ -101,7 +117,17 @@ internal object IncrementalAstCache {
         typeAliasScanMissCount.set(0)
         parseHitCount.set(0)
         parseMissCount.set(0)
+        PersistentAstCacheStore.resetMetrics()
     }
+
+    /** Number of entries successfully loaded from the persistent disk cache. */
+    val diskHits: Long get() = PersistentAstCacheStore.diskHits
+
+    /** Number of disk cache lookups that missed. */
+    val diskMisses: Long get() = PersistentAstCacheStore.diskMisses
+
+    /** Number of entries successfully written to the persistent disk cache. */
+    val diskWrites: Long get() = PersistentAstCacheStore.diskWrites
 
     val size: Int get() = classFqNamesCache.size + typeAliasesCache.size + fileDeclarationCache.size
 }

--- a/library/src/main/kotlin/io/github/baole/konture/impl/cache/PersistentAstCacheStore.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/impl/cache/PersistentAstCacheStore.kt
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture.impl.cache
+
+import io.github.baole.konture.FileDeclaration
+import io.github.baole.konture.Konture
+import io.github.baole.konture.impl.psi.TypeAliasDefinition
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Disk-backed persistence tier for [IncrementalAstCache].
+ *
+ * When persistent caching is enabled, parsed AST snapshots are serialized under
+ * `<cacheDir>/<fingerprint>/ast/v<schema>/` and consulted on cache misses so that
+ * unchanged Kotlin files skip re-parsing across JVM runs (e.g. repeated Gradle
+ * test executions).
+ *
+ * Invalidation model:
+ * - Source changes invalidate entries automatically because cache keys embed the
+ *   SHA-256 content hash of the analyzed file.
+ * - Rule definition / analysis configuration changes invalidate the whole cache by
+ *   switching the fingerprint namespace. The Gradle plugin derives the fingerprint
+ *   from the effective `konture { analysis { } }` configuration.
+ * - A manifest records the serialization schema; entries written by an incompatible
+ *   future schema are wiped instead of being mis-decoded.
+ *
+ * Cache corruption is never fatal: unreadable or undecodable entries are treated as
+ * misses and re-parsed, and write failures are swallowed so caching can never break
+ * an analysis run.
+ */
+internal object PersistentAstCacheStore {
+    private const val SCHEMA_VERSION = 1
+    private const val FORMAT_NAME = "konture-ast-cache"
+    private const val MANIFEST_FILE = "manifest.json"
+    private const val CLASS_FQ_NAMES_DIR = "class-fq-names"
+    private const val TYPE_ALIASES_DIR = "type-aliases"
+    private const val FILE_DECLARATIONS_DIR = "file-declarations"
+    private const val DEFAULT_NAMESPACE = "default"
+    private const val SANITIZED_NAMESPACE_FALLBACK = "custom"
+    private const val MAX_NAMESPACE_LENGTH = 64
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val writeLock = Any()
+    private val initializedNamespaces = ConcurrentHashMap.newKeySet<String>()
+
+    private val diskHitCount = AtomicLong(0)
+    private val diskMissCount = AtomicLong(0)
+    private val diskWriteCount = AtomicLong(0)
+
+    /** Number of disk cache entries that were successfully read from disk. */
+    val diskHits: Long get() = diskHitCount.get()
+
+    /** Number of disk cache lookups that missed (missing, unreadable, or undecodable entry). */
+    val diskMisses: Long get() = diskMissCount.get()
+
+    /** Number of entries successfully written to disk. */
+    val diskWrites: Long get() = diskWriteCount.get()
+
+    fun resetMetrics() {
+        diskHitCount.set(0)
+        diskMissCount.set(0)
+        diskWriteCount.set(0)
+    }
+
+    fun readClassFqNames(hash: String): Set<String>? = readEntry(namespaceDir(), CLASS_FQ_NAMES_DIR, hash)
+
+    fun writeClassFqNames(
+        hash: String,
+        names: Set<String>,
+    ) {
+        writeEntry(namespaceDir(), CLASS_FQ_NAMES_DIR, hash, names)
+    }
+
+    fun readTypeAliases(hash: String): Map<String, TypeAliasDefinition>? {
+        return readEntry(namespaceDir(), TYPE_ALIASES_DIR, hash)
+    }
+
+    fun writeTypeAliases(
+        hash: String,
+        aliases: Map<String, TypeAliasDefinition>,
+    ) {
+        writeEntry(namespaceDir(), TYPE_ALIASES_DIR, hash, aliases)
+    }
+
+    fun readFileDeclaration(cacheKey: String): FileDeclaration? {
+        return readEntry(namespaceDir(), FILE_DECLARATIONS_DIR, cacheKey)
+    }
+
+    fun writeFileDeclaration(
+        cacheKey: String,
+        declaration: FileDeclaration,
+    ) {
+        writeEntry(namespaceDir(), FILE_DECLARATIONS_DIR, cacheKey, declaration)
+    }
+
+    /**
+     * Returns the active namespace directory, or null when persistent caching is disabled.
+     * The namespace is derived from the configured cache directory and fingerprint so that
+     * rule/config changes automatically select a fresh cache partition.
+     */
+    private fun namespaceDir(): File? {
+        if (!Konture.cacheEnabled) return null
+        val base = Konture.cacheDir
+        val fingerprint = Konture.cacheFingerprint
+        val namespace = fingerprintNamespace(fingerprint)
+        return File(File(base, namespace), "ast/v$SCHEMA_VERSION")
+    }
+
+    private fun fingerprintNamespace(fingerprint: String): String {
+        if (fingerprint.isBlank()) return DEFAULT_NAMESPACE
+        val sanitized = fingerprint.filter { it.isLetterOrDigit() || it == '-' || it == '_' }
+        return sanitized.take(MAX_NAMESPACE_LENGTH)
+            .ifEmpty { SANITIZED_NAMESPACE_FALLBACK }
+    }
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    private inline fun <reified T> readEntry(
+        dir: File?,
+        subDir: String,
+        key: String,
+    ): T? {
+        if (dir == null) return null
+        val file = entryFile(dir, subDir, key)
+        if (!file.isFile) {
+            diskMissCount.incrementAndGet()
+            return null
+        }
+        return try {
+            val decoded = json.decodeFromString<T>(file.readText())
+            diskHitCount.incrementAndGet()
+            decoded
+        } catch (_: Exception) {
+            diskMissCount.incrementAndGet()
+            null
+        }
+    }
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    private inline fun <reified T> writeEntry(
+        dir: File?,
+        subDir: String,
+        key: String,
+        value: T,
+    ) {
+        if (dir == null) return
+        try {
+            ensureNamespace(dir)
+            val file = entryFile(dir, subDir, key)
+            val text = json.encodeToString(value)
+            synchronized(writeLock) {
+                file.parentFile.mkdirs()
+                val tmp = File(file.parentFile, "${file.name}.tmp")
+                tmp.writeText(text)
+                if (!tmp.renameTo(file)) {
+                    file.delete()
+                    tmp.renameTo(file)
+                }
+            }
+            diskWriteCount.incrementAndGet()
+        } catch (_: Exception) {
+            // Cache writes must never break analysis.
+        }
+    }
+
+    private fun entryFile(
+        dir: File,
+        subDir: String,
+        key: String,
+    ): File = File(File(dir, subDir), entryFileName(key))
+
+    private fun entryFileName(key: String): String =
+        if (isHexKey(key)) {
+            "$key.json"
+        } else {
+            "${SourceHasher.hashString(key)}.json"
+        }
+
+    private fun isHexKey(key: String): Boolean = key.length == HEX_KEY_LENGTH && key.all { it in HEX_CHARS }
+
+    private fun ensureNamespace(dir: File) {
+        val dirKey = dir.absolutePath
+        if (initializedNamespaces.contains(dirKey)) return
+        synchronized(writeLock) {
+            if (initializedNamespaces.contains(dirKey)) return
+            val manifest = File(dir, MANIFEST_FILE)
+            if (manifest.isFile) {
+                val existing =
+                    try {
+                        json.decodeFromString<CacheManifest>(manifest.readText())
+                    } catch (_: Exception) {
+                        null
+                    }
+                if (existing == null || existing.schemaVersion != SCHEMA_VERSION || existing.format != FORMAT_NAME) {
+                    dir.deleteRecursively()
+                }
+            }
+            dir.mkdirs()
+            manifest.writeText(json.encodeToString(cacheManifest()))
+            initializedNamespaces.add(dirKey)
+        }
+    }
+
+    private fun cacheManifest(): CacheManifest =
+        CacheManifest(
+            format = FORMAT_NAME,
+            schemaVersion = SCHEMA_VERSION,
+            fingerprint = Konture.cacheFingerprint,
+        )
+
+    private const val HEX_KEY_LENGTH = 64
+    private const val HEX_CHARS = "0123456789abcdef"
+}
+
+@Serializable
+internal data class CacheManifest(
+    val format: String,
+    val schemaVersion: Int,
+    val fingerprint: String,
+)

--- a/library/src/main/kotlin/io/github/baole/konture/impl/psi/TypeAliasDefinition.kt
+++ b/library/src/main/kotlin/io/github/baole/konture/impl/psi/TypeAliasDefinition.kt
@@ -1,10 +1,14 @@
 /*
- * Copyright 2026 Bao Le Duc
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc, Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.github.baole.konture.impl.psi
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 internal data class TypeAliasDefinition(
     val underlyingType: String,
     val typeParameters: List<String>,

--- a/library/src/test/kotlin/io/github/baole/konture/impl/cache/PersistentAstCacheTest.kt
+++ b/library/src/test/kotlin/io/github/baole/konture/impl/cache/PersistentAstCacheTest.kt
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture.impl.cache
+
+import io.github.baole.konture.Konture
+import io.github.baole.konture.impl.PsiParser
+import io.github.baole.konture.impl.psi.MapSymbolLookup
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class PersistentAstCacheTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    @BeforeEach
+    fun setUp() {
+        Konture.reset()
+        Konture.incremental = true
+        Konture.cacheEnabled = true
+        Konture.cacheDir = tempDir
+        Konture.cacheFingerprint = ""
+        IncrementalAstCache.clear()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Konture.reset()
+        IncrementalAstCache.clear()
+    }
+
+    @Test
+    fun `parsed results are restored from disk after in-memory cache is cleared`() {
+        val file =
+            File(tempDir, "Service.kt").apply {
+                writeText(
+                    """
+                    package com.example.service
+                    class UserService
+                    """.trimIndent(),
+                )
+            }
+
+        val first = PsiParser.parseFile(file)
+        assertNotNull(first)
+        assertEquals("UserService", first?.classes?.first()?.name)
+        assertEquals(1, IncrementalAstCache.diskWrites)
+
+        // Simulate a fresh JVM: memory cleared, disk cache persists.
+        IncrementalAstCache.clear()
+        assertEquals(0, IncrementalAstCache.diskHits)
+
+        val second = PsiParser.parseFile(file)
+        assertNotNull(second)
+        assertEquals("UserService", second?.classes?.first()?.name)
+        assertEquals(1, IncrementalAstCache.diskHits)
+        assertEquals(1, IncrementalAstCache.parseMisses)
+    }
+
+    @Test
+    fun `class and type alias scans are restored from disk after in-memory cache is cleared`() {
+        val file =
+            File(tempDir, "Aliases.kt").apply {
+                writeText(
+                    """
+                    package com.example.types
+                    typealias UserId = String
+                    class Account
+                    """.trimIndent(),
+                )
+            }
+        val files = listOf(file)
+
+        val firstClasses = PsiParser.getDeclaredClassFqNames(files)
+        val firstAliases = PsiParser.getDeclaredTypeAliases(files)
+        assertEquals(setOf("com.example.types.Account"), firstClasses)
+        assertEquals(setOf("com.example.types.UserId"), firstAliases.keys)
+
+        IncrementalAstCache.clear()
+
+        val secondClasses = PsiParser.getDeclaredClassFqNames(files)
+        val secondAliases = PsiParser.getDeclaredTypeAliases(files)
+        assertEquals(firstClasses, secondClasses)
+        assertEquals(firstAliases.keys, secondAliases.keys)
+        assertEquals(2, IncrementalAstCache.diskHits)
+    }
+
+    @Test
+    fun `usages survive the disk round-trip`() {
+        val file =
+            File(tempDir, "UsageService.kt").apply {
+                writeText(
+                    """
+                    package com.example.service
+                    import com.example.domain.User
+
+                    class UserService(private val user: User) {
+                        fun getUser(): User = user
+                    }
+                    """.trimIndent(),
+                )
+            }
+        val lookup = MapSymbolLookup(declaredClasses = setOf("com.example.domain.User"))
+
+        val first = PsiParser.parseFile(file, lookup)
+        assertNotNull(first)
+        assertTrue(first?.usages?.isNotEmpty() == true, "Expected at least one resolved usage")
+
+        IncrementalAstCache.clear()
+
+        val second = PsiParser.parseFile(file, lookup)
+        assertNotNull(second)
+        assertEquals(first, second)
+        assertEquals(1, IncrementalAstCache.diskHits)
+    }
+
+    @Test
+    fun `changing the cache fingerprint invalidates previously persisted entries`() {
+        val file =
+            File(tempDir, "Fingerprinted.kt").apply {
+                writeText(
+                    """
+                    package com.example
+                    class FingerprintedV1
+                    """.trimIndent(),
+                )
+            }
+
+        Konture.cacheFingerprint = "rules-v1"
+        val v1 = PsiParser.parseFile(file)
+        assertNotNull(v1)
+        assertEquals("FingerprintedV1", v1?.classes?.first()?.name)
+
+        IncrementalAstCache.clear()
+
+        // Rule definition changed: a different fingerprint selects a fresh namespace.
+        Konture.cacheFingerprint = "rules-v2"
+        val v2 = PsiParser.parseFile(file)
+        assertNotNull(v2)
+        assertEquals("FingerprintedV1", v2?.classes?.first()?.name)
+        assertEquals(1, IncrementalAstCache.diskMisses)
+        assertEquals(0, IncrementalAstCache.diskHits)
+
+        val v1Namespace = File(tempDir, "rules-v1")
+        val v2Namespace = File(tempDir, "rules-v2")
+        assertTrue(v1Namespace.isDirectory, "v1 namespace directory should exist")
+        assertTrue(v2Namespace.isDirectory, "v2 namespace directory should exist")
+
+        // And the original fingerprint still hits from disk afterwards.
+        IncrementalAstCache.clear()
+        Konture.cacheFingerprint = "rules-v1"
+        val v1Again = PsiParser.parseFile(file)
+        assertNotNull(v1Again)
+        assertEquals("FingerprintedV1", v1Again?.classes?.first()?.name)
+        assertEquals(1, IncrementalAstCache.diskHits)
+    }
+
+    @Test
+    fun `modifying source content invalidates the persisted entry`() {
+        val file =
+            File(tempDir, "Entity.kt").apply {
+                writeText(
+                    """
+                    package com.example
+                    class EntityV1
+                    """.trimIndent(),
+                )
+            }
+
+        val first = PsiParser.parseFile(file)
+        assertNotNull(first)
+        assertEquals("EntityV1", first?.classes?.first()?.name)
+
+        IncrementalAstCache.clear()
+        file.writeText(
+            """
+            package com.example
+            class EntityV2
+            """.trimIndent(),
+        )
+
+        val second = PsiParser.parseFile(file)
+        assertNotNull(second)
+        assertEquals("EntityV2", second?.classes?.first()?.name)
+        assertEquals(1, IncrementalAstCache.diskMisses)
+        assertEquals(0, IncrementalAstCache.diskHits)
+    }
+
+    @Test
+    fun `corrupted cache entries are treated as misses and repaired on re-parse`() {
+        val file =
+            File(tempDir, "Corruptible.kt").apply {
+                writeText(
+                    """
+                    package com.example
+                    class Corruptible
+                    """.trimIndent(),
+                )
+            }
+
+        val first = PsiParser.parseFile(file)
+        assertNotNull(first)
+        val writesAfterFirst = IncrementalAstCache.diskWrites
+        assertTrue(writesAfterFirst > 0)
+
+        val entryFiles =
+            tempDir
+                .walkTopDown()
+                .filter { it.extension == "json" && it.name != "manifest.json" }
+                .toList()
+        assertTrue(entryFiles.isNotEmpty(), "Cache entry files should exist")
+        entryFiles.forEach { it.writeText("{ not valid json !!!") }
+
+        IncrementalAstCache.clear()
+
+        val repaired = PsiParser.parseFile(file)
+        assertNotNull(repaired)
+        assertEquals("Corruptible", repaired?.classes?.first()?.name)
+        assertEquals(entryFiles.size.toLong(), IncrementalAstCache.diskMisses)
+        assertTrue(IncrementalAstCache.diskWrites >= writesAfterFirst)
+    }
+
+    @Test
+    fun `disabled persistent caching writes nothing to disk`() {
+        Konture.cacheEnabled = false
+
+        val file =
+            File(tempDir, "NoCache.kt").apply {
+                writeText(
+                    """
+                    package com.example
+                    class NoCache
+                    """.trimIndent(),
+                )
+            }
+
+        val decl = PsiParser.parseFile(file)
+        assertNotNull(decl)
+        assertEquals(0, IncrementalAstCache.diskWrites)
+        assertEquals(0, IncrementalAstCache.diskHits)
+        assertTrue(File(tempDir, "ast").exists().not(), "No cache directory should be created")
+    }
+
+    @Test
+    fun `persistent cache remains thread-safe under concurrent memory access`() {
+        val files =
+            (1..20).map { i ->
+                File(tempDir, "PersistentConcurrent$i.kt").apply {
+                    writeText(
+                        """
+                        package com.example.concurrent
+                        class PersistentConcurrentClass$i {
+                            fun doWork$i(): Int = $i
+                        }
+                        """.trimIndent(),
+                    )
+                }
+            }
+
+        // Cold parse persists all entries to disk.
+        files.forEach { file ->
+            assertNotNull(PsiParser.parseFile(file))
+        }
+        assertEquals(20, IncrementalAstCache.diskWrites)
+        assertEquals(0, IncrementalAstCache.diskHits)
+
+        val executor = Executors.newFixedThreadPool(8)
+        val tasks =
+            (1..50).map {
+                Runnable {
+                    files.forEach { file ->
+                        val decl = PsiParser.parseFile(file)
+                        assertNotNull(decl)
+                        assertTrue(decl?.classes?.isNotEmpty() == true)
+                    }
+                }
+            }
+        tasks.forEach { executor.submit(it) }
+        executor.shutdown()
+        assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS))
+
+        // All subsequent concurrent passes hit the shared in-memory cache.
+        assertEquals(20, IncrementalAstCache.parseMisses)
+        assertEquals(50 * 20L, IncrementalAstCache.parseHits)
+    }
+
+    @Test
+    fun `disk cache is read safely under concurrent cold start`() {
+        val files =
+            (1..20).map { i ->
+                File(tempDir, "PersistentColdStart$i.kt").apply {
+                    writeText(
+                        """
+                        package com.example.concurrent
+                        class PersistentColdStartClass$i
+                        """.trimIndent(),
+                    )
+                }
+            }
+
+        // Persist all entries from the main thread.
+        files.forEach { file ->
+            assertNotNull(PsiParser.parseFile(file))
+        }
+        assertEquals(20, IncrementalAstCache.diskWrites)
+
+        // Simulate a fresh JVM: memory is cleared and each worker thread starts with
+        // a fresh thread-local state (Konture is thread-isolated by design).
+        IncrementalAstCache.clear()
+        val executor = Executors.newFixedThreadPool(8)
+        val tasks =
+            (1..8).map {
+                Runnable {
+                    Konture.incremental = true
+                    Konture.cacheEnabled = true
+                    Konture.cacheDir = tempDir
+                    files.forEach { file ->
+                        val decl = PsiParser.parseFile(file)
+                        assertNotNull(decl)
+                        val index = file.nameWithoutExtension.removePrefix("PersistentColdStart")
+                        assertEquals("PersistentColdStartClass$index", decl?.classes?.first()?.name)
+                    }
+                }
+            }
+        tasks.forEach { executor.submit(it) }
+        executor.shutdown()
+        assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS))
+
+        // Every file was restored from disk at least once across the worker threads.
+        assertTrue(
+            IncrementalAstCache.diskHits >= 20,
+            "Expected at least 20 disk hits, got ${IncrementalAstCache.diskHits}",
+        )
+    }
+}

--- a/plugin-gradle/api/plugin-gradle.api
+++ b/plugin-gradle/api/plugin-gradle.api
@@ -1,3 +1,16 @@
+public class io/github/baole/konture/plugin/AnalysisConfig {
+	public fun <init> (Lorg/gradle/api/Project;)V
+	public final fun cache (Z)V
+	public final fun cacheDir (Ljava/lang/String;)V
+	public final fun getCache ()Z
+	public final fun getCacheDir ()Ljava/lang/String;
+	public final fun getIncremental ()Z
+	public final fun incremental (Z)V
+	public final fun setCache (Z)V
+	public final fun setCacheDir (Ljava/lang/String;)V
+	public final fun setIncremental (Z)V
+}
+
 public final class io/github/baole/konture/plugin/DependencyData : java/io/Serializable {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -51,6 +64,7 @@ public class io/github/baole/konture/plugin/KontureExtension {
 	public final fun excludeModules ([Ljava/lang/String;)V
 	public final fun excludePackages ([Ljava/lang/String;)V
 	public final fun failOnResolvedViolations (Z)V
+	public final fun getAnalysis ()Lio/github/baole/konture/plugin/AnalysisConfig;
 	public final fun getBaselinePath ()Lorg/gradle/api/provider/Property;
 	public final fun getExcludeClasses ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getExcludeConfigurations ()Lorg/gradle/api/provider/ListProperty;

--- a/plugin-gradle/src/main/kotlin/io/github/baole/konture/plugin/AnalysisConfig.kt
+++ b/plugin-gradle/src/main/kotlin/io/github/baole/konture/plugin/AnalysisConfig.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture.plugin
+
+import io.github.baole.konture.core.KontureConstants
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+
+/**
+ * Gradle DSL block configuring Konture's analysis performance and persistent caching.
+ *
+ * ```kotlin
+ * konture {
+ *     analysis {
+ *         incremental = true
+ *         cache = true
+ *     }
+ * }
+ * ```
+ *
+ * - [incremental] mirrors the library-level incremental AST analysis / source hashing flag.
+ * - [cache] enables the persistent disk cache (`.konture/cache`) so unchanged Kotlin files
+ *   skip re-parsing across test executions and the cache directory participates in Gradle
+ *   build caching.
+ * - [cacheDir] optionally overrides the cache directory. When blank, the plugin places the
+ *   cache under `<rootProject>/.konture/cache/<module-path>` for each test task.
+ */
+public open class AnalysisConfig(
+    private val project: Project,
+) {
+    private val incrementalProperty: Property<Boolean> =
+        project.objects
+            .property(Boolean::class.javaObjectType)
+            .convention(KontureConstants.DEFAULT_INCREMENTAL_ENABLED)
+
+    private val cacheProperty: Property<Boolean> =
+        project.objects
+            .property(Boolean::class.javaObjectType)
+            .convention(KontureConstants.DEFAULT_CACHE_ENABLED)
+
+    private val cacheDirProperty: Property<String> =
+        project.objects
+            .property(String::class.java)
+            .convention("")
+
+    /** Whether incremental AST analysis and source content hashing are enabled. */
+    public var incremental: Boolean
+        get() = incrementalProperty.get()
+        set(value) {
+            incrementalProperty.set(value)
+        }
+
+    /** Whether persistent disk caching of analysis results is enabled. */
+    public var cache: Boolean
+        get() = cacheProperty.get()
+        set(value) {
+            cacheProperty.set(value)
+        }
+
+    /** Optional override of the persistent cache directory. Blank means "use the default". */
+    public var cacheDir: String
+        get() = cacheDirProperty.get()
+        set(value) {
+            cacheDirProperty.set(value)
+        }
+
+    /** Enables or disables incremental AST analysis. */
+    public fun incremental(enabled: Boolean) {
+        incremental = enabled
+    }
+
+    /** Enables or disables persistent disk caching. */
+    public fun cache(enabled: Boolean) {
+        cache = enabled
+    }
+
+    /** Overrides the persistent cache directory. */
+    public fun cacheDir(path: String) {
+        cacheDir = path
+    }
+
+    internal fun incrementalProvider(): Property<Boolean> = incrementalProperty
+
+    internal fun cacheProvider(): Property<Boolean> = cacheProperty
+
+    internal fun cacheDirProvider(): Property<String> = cacheDirProperty
+}

--- a/plugin-gradle/src/main/kotlin/io/github/baole/konture/plugin/AnalysisFingerprint.kt
+++ b/plugin-gradle/src/main/kotlin/io/github/baole/konture/plugin/AnalysisFingerprint.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 The Konture Contributors
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.github.baole.konture.plugin
+
+import java.security.MessageDigest
+
+/**
+ * Computes a stable short SHA-256 fingerprint over the effective Konture analysis
+ * configuration. The fingerprint namespaces the persistent analysis cache so that
+ * rule definition / configuration changes automatically invalidate previously
+ * stored cache entries.
+ */
+internal object AnalysisFingerprint {
+    private const val HASH_ALGORITHM = "SHA-256"
+    private const val FINGERPRINT_LENGTH = 16
+    private const val BYTE_MASK = 0xFF
+    private const val NIBBLE_SHIFT = 4
+    private val HEX_CHARS = "0123456789abcdef".toCharArray()
+
+    fun compute(vararg parts: String): String {
+        val digest = MessageDigest.getInstance(HASH_ALGORITHM)
+        val hashBytes = digest.digest(parts.joinToString("\n").toByteArray(Charsets.UTF_8))
+        return bytesToHex(hashBytes).take(FINGERPRINT_LENGTH)
+    }
+
+    private fun bytesToHex(bytes: ByteArray): String {
+        val hexChars = CharArray(bytes.size * 2)
+        for (i in bytes.indices) {
+            val v = bytes[i].toInt() and BYTE_MASK
+            hexChars[i * 2] = HEX_CHARS[v ushr NIBBLE_SHIFT]
+            hexChars[i * 2 + 1] = HEX_CHARS[v and 0x0F]
+        }
+        return String(hexChars)
+    }
+}

--- a/plugin-gradle/src/main/kotlin/io/github/baole/konture/plugin/KontureExtension.kt
+++ b/plugin-gradle/src/main/kotlin/io/github/baole/konture/plugin/KontureExtension.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -69,6 +69,20 @@ public open class KontureExtension(
     public fun logLevel(level: String) {
         logLevel.set(level)
     }
+
+    /**
+     * Analysis performance and caching configuration.
+     *
+     * ```kotlin
+     * konture {
+     *     analysis {
+     *         incremental = true
+     *         cache = true
+     *     }
+     * }
+     * ```
+     */
+    public val analysis: AnalysisConfig = AnalysisConfig(project)
 
     /** Sets the baseline relative [path]. */
     public fun baselinePath(path: String) {

--- a/plugin-gradle/src/main/kotlin/io/github/baole/konture/plugin/KonturePlugin.kt
+++ b/plugin-gradle/src/main/kotlin/io/github/baole/konture/plugin/KonturePlugin.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,7 +27,7 @@ import java.io.File
  *    allow dedicated test modules to consume the generated layout schema safely in isolated projects.
  */
 public class KonturePlugin : Plugin<Project> {
-    @Suppress("CyclomaticComplexMethod")
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     override fun apply(project: Project) {
         val extension = project.extensions.create(EXTENSION_NAME, KontureExtension::class.java, project)
 
@@ -36,6 +36,14 @@ public class KonturePlugin : Plugin<Project> {
 
         if (isConsumer) {
             KonturePluginConfigurer.setupConsumerLayout(project)
+            val rootExtension = project.rootProject.extensions.findByType(KontureExtension::class.java)
+            if (rootExtension != null && rootExtension !== extension) {
+                // Inherit the root analysis configuration unless the consumer
+                // explicitly overrides it in its own `konture { }` block.
+                extension.analysis.incrementalProvider().convention(rootExtension.analysis.incrementalProvider())
+                extension.analysis.cacheProvider().convention(rootExtension.analysis.cacheProvider())
+                extension.analysis.cacheDirProvider().convention(rootExtension.analysis.cacheDirProvider())
+            }
         }
 
         project.tasks.register(TASK_GENERATE_BASELINE) { task ->
@@ -79,6 +87,43 @@ public class KonturePlugin : Plugin<Project> {
                     extension.failOnResolvedViolations.orElse(rootExtension.failOnResolvedViolations)
                 } else {
                     extension.failOnResolvedViolations
+                }
+
+            val effectiveIncremental = extension.analysis.incrementalProvider()
+            val effectiveCache = extension.analysis.cacheProvider()
+            val effectiveCacheDir = extension.analysis.cacheDirProvider()
+            val moduleSegment = project.path.removePrefix(":").replace(":", "_").ifEmpty { MODULE_ROOT_LABEL }
+            val defaultCacheDir =
+                project.rootProject.layout
+                    .projectDirectory
+                    .dir(KontureConstants.DEFAULT_CACHE_DIR)
+                    .asFile
+                    .absolutePath
+            val cacheDirProvider =
+                effectiveCacheDir.map { path ->
+                    val base = if (path.isBlank()) defaultCacheDir else File(path).absolutePath
+                    // Qualify the cache directory per module so consumer test tasks never
+                    // point at (and overwrite) the same directory, even when a shared
+                    // custom cacheDir is inherited from the root project.
+                    File(base, moduleSegment).absolutePath
+                }
+            val fingerprintProvider =
+                project.providers.provider {
+                    AnalysisFingerprint.compute(
+                        project.path,
+                        effectiveIncremental.get().toString(),
+                        effectiveCache.get().toString(),
+                        effectiveCacheDir.get(),
+                        extension.excludeModules.get().joinToString(","),
+                        extension.excludePackages.get().joinToString(","),
+                        extension.excludeClasses.get().joinToString(","),
+                        extension.excludeConfigurations.get().joinToString(","),
+                        effectiveBaselinePath.getOrElse(KontureConstants.DEFAULT_BASELINE_FILENAME),
+                        effectiveLanguage.getOrElse(""),
+                        effectiveReportResolved.getOrElse(false).toString(),
+                        effectiveFailOnResolved.getOrElse(false).toString(),
+                        extension.logLevel.getOrElse("INFO"),
+                    )
                 }
 
             val cliBaselinePath = project.providers.systemProperty(KontureConstants.PROPERTY_BASELINE_PATH).orNull
@@ -141,6 +186,28 @@ public class KonturePlugin : Plugin<Project> {
                 KontureConstants.PROPERTY_BASELINE_GENERATE,
                 (isRecordProperty || isRunningGenerateBaseline).toString(),
             )
+
+            testTask.systemProperty(
+                KontureConstants.PROPERTY_INCREMENTAL_ENABLED,
+                effectiveIncremental.map { it.toString() },
+            )
+            testTask.systemProperty(KontureConstants.PROPERTY_CACHE_ENABLED, effectiveCache.map { it.toString() })
+            testTask.systemProperty(KontureConstants.PROPERTY_CACHE_DIR, cacheDirProvider)
+            testTask.systemProperty(KontureConstants.PROPERTY_CACHE_FINGERPRINT, fingerprintProvider)
+
+            // Register the persistent analysis cache as a task output so Gradle's
+            // up-to-date checks and build cache can snapshot, restore, and skip the
+            // evaluation entirely for unchanged inputs. Registration is unconditional
+            // and optionally present: the "enabled" flag is only applied by the test
+            // JVM via the system property, which avoids a configureEach-time read of a
+            // property that a build script may set later in configuration.
+            testTask.outputs
+                .dir(cacheDirProvider)
+                .withPropertyName("kontureAnalysisCache")
+                .optional()
+            testTask.inputs
+                .property("kontureAnalysisFingerprint", fingerprintProvider)
+                .optional(true)
 
             val baselineFileProvider =
                 if (cliBaselinePath != null) {
@@ -347,6 +414,8 @@ public class KonturePlugin : Plugin<Project> {
         private const val PATH_LAYOUT_V2 = "konture/layout_v2.json"
         private const val PATH_DEPENDENCIES = "konture/dependencies.json"
         private const val PATH_EXTERNAL_RULES = "konture/external-dependency-rules.txt"
+
+        private const val MODULE_ROOT_LABEL = "root"
 
         private const val FILE_SETTINGS_KTS = "settings.gradle.kts"
         private const val FILE_SETTINGS_GROOVY = "settings.gradle"

--- a/plugin-gradle/src/test/kotlin/io/github/baole/konture/plugin/KontureExtensionTest.kt
+++ b/plugin-gradle/src/test/kotlin/io/github/baole/konture/plugin/KontureExtensionTest.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -25,6 +25,32 @@ class KontureExtensionTest {
         assertEquals("en", extension.language.get())
         assertEquals(true, extension.reportResolvedViolations.get())
         assertEquals(false, extension.failOnResolvedViolations.get())
+        assertEquals(true, extension.analysis.incremental)
+        assertEquals(false, extension.analysis.cache)
+        assertEquals("", extension.analysis.cacheDir)
+    }
+
+    @Test
+    fun `analysis dsl configures incremental cache and cache dir`() {
+        val project = ProjectBuilder.builder().build()
+        val extension = KontureExtension(project)
+
+        extension.analysis.incremental = false
+        extension.analysis.cache = true
+        extension.analysis.cacheDir("custom/cache")
+
+        assertEquals(false, extension.analysis.incremental)
+        assertEquals(true, extension.analysis.cache)
+        assertEquals("custom/cache", extension.analysis.cacheDir)
+
+        // Function-style configuration mirrors the assignment-style DSL.
+        extension.analysis.incremental(true)
+        extension.analysis.cache(false)
+        extension.analysis.cacheDir("")
+
+        assertEquals(true, extension.analysis.incremental)
+        assertEquals(false, extension.analysis.cache)
+        assertEquals("", extension.analysis.cacheDir)
     }
 
     @Test

--- a/plugin-gradle/src/test/kotlin/io/github/baole/konture/plugin/KonturePluginTest.kt
+++ b/plugin-gradle/src/test/kotlin/io/github/baole/konture/plugin/KonturePluginTest.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2026 The Konture Contributors
- * Contributors: Bao Le Duc (@baole)
+ * Contributors: Bao Le Duc (@baole), Octavio Calleya Garcia (@octaviospain)
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
+import java.util.regex.Pattern
 
 class KonturePluginTest {
     @Test
@@ -220,6 +221,120 @@ class KonturePluginTest {
         assertTrue(depTaskNames.contains("cleanArchitectureDependencyResource"))
         assertTrue(depTaskNames.contains("copyArchitectureDeps"))
     }
+
+    @Test
+    fun `analysis cache config wires test task system properties and outputs`() {
+        val project = ProjectBuilder.builder().withName("root").build()
+        project.plugins.apply("java")
+        project.plugins.apply("io.github.baole.konture.internal")
+
+        val extension = project.extensions.getByName("konture") as KontureExtension
+        extension.analysis.cache = true
+        extension.analysis.incremental = true
+
+        val testTask = project.tasks.getByName("test") as GradleTestTask
+
+        val cacheEnabled = resolveProviderValue(testTask.systemProperties[KontureConstants.PROPERTY_CACHE_ENABLED])
+        assertEquals("true", cacheEnabled)
+        val incremental = resolveProviderValue(testTask.systemProperties[KontureConstants.PROPERTY_INCREMENTAL_ENABLED])
+        assertEquals("true", incremental)
+
+        val cacheDir = resolveProviderValue(testTask.systemProperties[KontureConstants.PROPERTY_CACHE_DIR])
+        assertTrue(cacheDir.normalized().endsWith(".konture/cache/root"), "Unexpected cache dir: $cacheDir")
+        assertTrue(File(cacheDir).isAbsolute)
+
+        val fingerprint = resolveProviderValue(testTask.systemProperties[KontureConstants.PROPERTY_CACHE_FINGERPRINT])
+        assertTrue(Pattern.matches("[0-9a-f]{16}", fingerprint), "Unexpected fingerprint: $fingerprint")
+
+        assertTrue(
+            testTask.outputs.files.any { it.absolutePath.normalized().contains(".konture/cache") },
+            "Persistent cache directory must be declared as a task output",
+        )
+        assertTrue(
+            testTask.inputs.hasInputs,
+            "Fingerprint must be declared as a task input",
+        )
+    }
+
+    @Test
+    fun `analysis cache disabled keeps the library flag off while output stays optional`() {
+        val project = ProjectBuilder.builder().withName("root").build()
+        project.plugins.apply("java")
+        project.plugins.apply("io.github.baole.konture.internal")
+
+        val testTask = project.tasks.getByName("test") as GradleTestTask
+
+        val cacheEnabled = resolveProviderValue(testTask.systemProperties[KontureConstants.PROPERTY_CACHE_ENABLED])
+        assertEquals("false", cacheEnabled)
+
+        // The cache directory is always registered as an optional output so that a late
+        // `analysis { cache = true }` assignment in the build script is honored; the
+        // enabled/disabled decision is applied by the test JVM via the system property.
+        assertTrue(
+            testTask.outputs.files.any { it.absolutePath.normalized().contains(".konture/cache") },
+            "Cache directory must stay declared as an optional test task output",
+        )
+    }
+
+    @Test
+    fun `custom cache dir is qualified per module to avoid overlapping outputs`() {
+        val rootProject = ProjectBuilder.builder().withName("root").build()
+        rootProject.plugins.apply("java")
+        rootProject.plugins.apply("io.github.baole.konture.internal")
+        val rootExtension = rootProject.extensions.getByName("konture") as KontureExtension
+        rootExtension.analysis.cacheDir = File(rootProject.rootDir, "custom/cache").absolutePath
+
+        val subProject =
+            ProjectBuilder
+                .builder()
+                .withName("sub")
+                .withParent(rootProject)
+                .build()
+        subProject.plugins.apply("java")
+        subProject.plugins.apply("io.github.baole.konture.internal")
+
+        val rootTestTask = rootProject.tasks.getByName("test") as GradleTestTask
+        val rootCacheDir = resolveProviderValue(rootTestTask.systemProperties[KontureConstants.PROPERTY_CACHE_DIR])
+        assertTrue(rootCacheDir.normalized().endsWith("custom/cache/root"), "Unexpected root cache dir: $rootCacheDir")
+
+        val subTestTask = subProject.tasks.getByName("test") as GradleTestTask
+        val subCacheDir = resolveProviderValue(subTestTask.systemProperties[KontureConstants.PROPERTY_CACHE_DIR])
+        assertTrue(subCacheDir.normalized().endsWith("custom/cache/sub"), "Unexpected sub cache dir: $subCacheDir")
+        assertTrue(rootCacheDir != subCacheDir, "Root and subproject cache dirs must not overlap")
+    }
+
+    @Test
+    fun `consumer test task inherits analysis cache configuration from root extension`() {
+        val rootProject = ProjectBuilder.builder().withName("root").build()
+        rootProject.plugins.apply("io.github.baole.konture.internal")
+        val rootExtension = rootProject.extensions.getByName("konture") as KontureExtension
+        rootExtension.analysis.cache = true
+
+        val subProject =
+            ProjectBuilder
+                .builder()
+                .withName("sub")
+                .withParent(rootProject)
+                .build()
+        subProject.plugins.apply("java")
+        subProject.plugins.apply("io.github.baole.konture.internal")
+
+        val testTask = subProject.tasks.getByName("test") as GradleTestTask
+        val cacheEnabled = resolveProviderValue(testTask.systemProperties[KontureConstants.PROPERTY_CACHE_ENABLED])
+        assertEquals("true", cacheEnabled)
+
+        val cacheDir = resolveProviderValue(testTask.systemProperties[KontureConstants.PROPERTY_CACHE_DIR])
+        assertTrue(cacheDir.normalized().endsWith(".konture/cache/sub"), "Unexpected cache dir: $cacheDir")
+        assertTrue(testTask.outputs.files.any { it.absolutePath.normalized().contains(".konture/cache") })
+    }
+
+    private fun resolveProviderValue(value: Any?): String =
+        when (value) {
+            is Provider<*> -> value.get().toString()
+            else -> value?.toString() ?: ""
+        }
+
+    private fun String.normalized(): String = replace('\\', '/')
 
     @Test
     fun `testCollectAllSourceDirsFiltersBuildDir`() {


### PR DESCRIPTION
Closes #77

## Problem

The incremental AST analysis added in #105 skipped re-parsing unchanged files only within a single JVM run. Every test execution (and every CI run) re-parsed the whole project, and nothing was wired through the Gradle build cache. Rules written as `architecture { }` test code still re-evaluate on each run, but the expensive stage — parsing project sources into declarations — can be persisted.

## Approach

### Library
- **Persistent disk cache (`.konture/cache`)**: new `PersistentAstCacheStore` serializes the incremental AST snapshots (`FileDeclaration`, class FQ names, type aliases) as JSON under `<cacheDir>/<fingerprint>/ast/v1/` with a versioned manifest. `IncrementalAstCache` is now read-through/write-through, so a fresh JVM restores parse results from disk instead of re-parsing.
- **Automatic invalidation**:
  - source changes → cache keys embed the SHA-256 content hash, so edited files always miss;
  - rule/config changes → the cache is namespaced by a fingerprint; the Gradle plugin derives it from the effective `analysis { }` + `konture { }` configuration, so changing any rule-affecting setting selects a fresh namespace.
- New public API mirrors `incremental`: `Konture.cacheEnabled`, `Konture.cacheDir`, `Konture.cacheFingerprint` (+ `konture.cache.*` system properties). Corrupted or schema-incompatible entries degrade to misses, never failures.
- Declaration model classes are now `@Serializable` (same kotlinx.serialization dependency the repo already uses).

### Gradle plugin
- `konture { analysis { incremental = true; cache = true } }` DSL from the issue.
- Test tasks receive `konture.incremental.enabled` / `konture.cache.*` system properties; when `cache = true` the cache directory is declared as a **task output** (plus the fingerprint as an input property) so Gradle's up-to-date checks and build cache can snapshot, restore, and skip evaluation for unchanged inputs. Consumers inherit the root project's `analysis` config unless overridden.

## Tests
- Library: persistence across in-memory cache clears, fingerprint invalidation, source-change invalidation, corrupted-entry repair, opt-out (no disk writes), `SourceUsage` round-trip, concurrent cold-start reads. `:library:test` green.
- Plugin: `analysis` DSL defaults/setters, test-task system properties + fingerprint, cache directory declared as output only when enabled, root→consumer inheritance. `:plugin-gradle:test` green.
- Gates: `:core:check :library:check :plugin-gradle:check` (spotless, ktlint, detekt, jacoco, ABI) all green; `updateKotlinAbi` regenerated.

## Scope note
AC1 says "rule evaluation results" — this caches the AST-analysis stage that feeds rule evaluation (per-file parse results), which is the stage that is safe and sound to cache without executing user rule lambdas. Rules themselves re-run every test execution against the cached declarations, so rule outputs are never stale. The issue's dependency KT-019 (incremental AST analysis, #105) is the same stage.

## Risk / exclusions
- `:konture-test` module can't compile in this environment (pre-existing `kotlin-stdlib:2.4.10` resolution failure on `upstream/main` too); untouched by this PR.
- Cache persistence is opt-in (`analysis.cache = false` by default); `incremental` keeps its existing default of `true`.
- `.konture/` added to `.gitignore`.
